### PR TITLE
feat: pageInfo 공통 컴포넌트 구현

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,0 +1,23 @@
+interface PageInfoData {
+	title: string;
+	description: string;
+	src: string;
+}
+
+export const PAGE_INFO: Record<string, PageInfoData> = {
+	meetings: {
+		title: '함께 할 사람이 없나요?',
+		description: '지금 모임에 참여해보세요',
+		src: '/images/head/headClass.png',
+	},
+	saved: {
+		title: '찜한 모임',
+		description: '지금 모임에 참여해보세요',
+		src: '/images/head/headSaved.png',
+	},
+	reviews: {
+		title: '모든 리뷰',
+		description: '같이달램을 이용한 분들은 이렇게 느꼈어요🫶',
+		src: '/images/head/headReview.png',
+	},
+};

--- a/src/app/components/PageInfo/PageInfo.tsx
+++ b/src/app/components/PageInfo/PageInfo.tsx
@@ -1,0 +1,33 @@
+import Image from 'next/image';
+import { PAGE_INFO } from '../../../../constants/index';
+
+interface PageInfoProps {
+	pageKey: string;
+	isTitleLarge?: boolean;
+}
+
+const PageInfo = ({ pageKey, isTitleLarge = true }: PageInfoProps) => {
+	const pageData = PAGE_INFO[pageKey];
+
+	return (
+		<div className="flex w-full p-4 items-center">
+			<div className="pr-4">
+				<Image src={pageData.src} alt={pageData.title} width={72} height={72} />
+			</div>
+			<div className="flex flex-col">
+				<div
+					className={`pb-2 ${isTitleLarge ? 'text-2xl font-semibold' : 'text-sm font-medium'}`}
+				>
+					{pageData.title}
+				</div>
+				<div
+					className={`${isTitleLarge ? 'text-sm font-medium' : 'text-2xl font-semibold'}`}
+				>
+					{pageData.description}
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default PageInfo;


### PR DESCRIPTION
**개요**
페이지 별 소개문구 공통 컴포넌트를 구현하였습니다.

**타입**

- [x] ✨feat: 기능 추가, 수정, 삭제
- [ ] 🐛fix: 버그, 오류 수정
- [ ] ⚙️config: npm 모듈 설치 , 설정 파일 추가, 라이브러리 추가 등
- [ ] 🌱chore: 그 외 기타 변경 사항에 대한 커밋(기타변경, 오탈자 수정,네이밍 변경 등)으로 프로덕션 코드 변경X
- [ ] 📝docs: README.md, json 파일 등 수정 (문서 관련, 코드 수정 없음)
- [ ] 🎨style: 코드 스타일 및 포맷 / CSS 등 사용자 UI 디자인 변경 (제품 코드 수정 발생, 코드 형식, 정렬 등의 변경)
- [ ] ♻️refactor: 코드 리팩토링
- [ ] 🧪test: 테스트 코드 추가, 삭제, 변경 등 (코드 수정 없음, 테스트 코드에 관련된 모든 변경에 해당)
- [ ] 🗑️remove: 파일을 삭제하는 작업만 수행한 경우

**작업 사항**
- constants 폴더에 index.ts 파일 안에 각 정보 객체를 넣었습니다.
- props로 각 페이지 관련 객체 key 값만 넣으면 컴포넌트를 쉽게 사용할 수 있게 해뒀습니다.
- isTitleLarge props 를 사용해 상단과 하단의 css가 바뀌는 것을 boolean으로 처리했습니다.

- 스크린샷
![image](https://github.com/user-attachments/assets/d8dd4217-91fa-4e60-bd58-2fd3c5c1c6ed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 페이지별 정보(타이틀, 설명, 이미지 등)를 쉽게 관리하고 표시할 수 있는 기능이 추가되었습니다.
	- 선택한 페이지에 맞춰 시각적으로 정보를 렌더링하는 컴포넌트가 도입되어, 보다 유연한 페이지 구성이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->