### PR TITLE
feat: Members 공통 컴포넌트 정원 마감 시 하이라이팅 기능 여부 선택 옵션으로 변경

### DIFF
--- a/src/app/(home)/mypage/page.tsx
+++ b/src/app/(home)/mypage/page.tsx
@@ -30,7 +30,7 @@ function MyPage() {
 			</div>
 			Members
 			<Members max={10} value={10} />
-			<Members max={10} value={15} />
+			<Members max={10} value={15} highLight={'off'} />
 			<Members max={10} value={5} />
 			<div className='flex flex-col items-start max-w-80 gap-2 p-1'>
 				<div>

--- a/src/components/Members/Members.tsx
+++ b/src/components/Members/Members.tsx
@@ -1,9 +1,10 @@
 interface MembersProps {
 	max: number;
 	value: number;
+	highLight?: 'on' | 'off';
 }
 
-function Members({ max, value }: MembersProps) {
+function Members({ max, value, highLight }: MembersProps) {
 	let maxCount = max;
 	let curCount = value;
 	const styleProp = {
@@ -25,8 +26,11 @@ function Members({ max, value }: MembersProps) {
 	// 들어온 값이 최대 인원을 초과할 경우 최대 인원까지만 표시
 	if (value >= max) {
 		curCount = Math.min(...[max, value].map((num) => Math.floor(num)));
-		styleProp.fillColor = 'fill-orange-400';
-		styleProp.textColor = 'text-orange-400';
+		// heighLight 값이 지정되지 않으면 기본 유지
+		styleProp.fillColor =
+			highLight === 'off' ? styleProp.fillColor : 'fill-orange-400';
+		styleProp.textColor =
+			highLight === 'off' ? styleProp.textColor : 'text-orange-400';
 	}
 
 	return (


### PR DESCRIPTION
**개요**

- 정원 마감시 텍스트 색상이 변경되는 기본 옵션을 선택으로 변경하였습니다.

**타입**

- [ ] ✨feat: 기능 추가, 수정, 삭제
- [ ] 🐛fix: 버그, 오류 수정
- [ ] ⚙️config: npm 모듈 설치 , 설정 파일 추가, 라이브러리 추가 등
- [ ] 🌱chore: 그 외 기타 변경 사항에 대한 커밋(기타변경, 오탈자 수정,네이밍 변경 등)으로 프로덕션 코드 변경X
- [ ] 📝docs: README.md, json 파일 등 수정 (문서 관련, 코드 수정 없음)
- [ ] 🎨style: 코드 스타일 및 포맷 / CSS 등 사용자 UI 디자인 변경 (제품 코드 수정 발생, 코드 형식, 정렬 등의 변경)
- [ ] ♻️refactor: 코드 리팩토링
- [ ] 🧪test: 테스트 코드 추가, 삭제, 변경 등 (코드 수정 없음, 테스트 코드에 관련된 모든 변경에 해당)
- [ ] 🗑️remove: 파일을 삭제하는 작업만 수행한 경우

**작업 사항**

- 텍스트 색상을 변경할지 말지 여부를 선택하는 `highLight` prop 을 추가하였습니다.
- 기본값은 'on' 이며, 선택 props 이기 때문에 색상 변경을 원하지 않을 경우 `highLight` 을 'off'로 전달할 수 있습니다

**Others - optional**

- 스크린샷이나 참고한 링크
