### PR TITLE
feat: ProfileHeader 컴포넌트 내부에서 유저 정보 가져오도록 변경

### DIFF
--- a/src/app/(home)/mypage/@profile/(.)my-profile/page.tsx
+++ b/src/app/(home)/mypage/@profile/(.)my-profile/page.tsx
@@ -1,8 +1,9 @@
+import { Modal } from '@/components/Modal/Modal';
 import ProfileForm from '../../components/ProfileForm/ProfileForm';
 import dynamic from 'next/dynamic';
 
 function Page() {
-	const Modal = dynamic(() => import('@/components/Modal/Modal'));
+	// const Modal = dynamic(() => import('@/components/Modal/Modal'));
 	return (
 		<Modal isOpen={true}>
 			<ProfileForm />

--- a/src/app/(home)/mypage/@review/(..)mypage/create-review/[id]/page.tsx
+++ b/src/app/(home)/mypage/@review/(..)mypage/create-review/[id]/page.tsx
@@ -1,5 +1,5 @@
 import ReviewForm from '@/app/(home)/mypage/components/ReviewForm/ReviewForm';
-import Modal from '@/components/Modal/Modal';
+import { Modal } from '@/components/Modal/Modal';
 
 function Page() {
 	return (

--- a/src/app/(home)/mypage/components/ProfileForm/ProfileForm.tsx
+++ b/src/app/(home)/mypage/components/ProfileForm/ProfileForm.tsx
@@ -8,7 +8,6 @@ import { FormEvent, useEffect, useState } from 'react';
 import { editProfile } from '@/api/users';
 import { getUserData } from '@/api/getUserData';
 import type { IUser } from '@/types/userType';
-import type { ProfileHeaderProps } from '../ProfileHeader/ProfileHeader';
 
 function ProfileForm() {
 	const [userData, setUserData] = useState<IUser | null>();
@@ -18,7 +17,6 @@ function ProfileForm() {
 	};
 	// const userData: Promise<IUser> = getData();
 
-	/** profile Header prop 확인을 위해 임시 작성 */
 	useEffect(() => {
 		getData();
 	}, []);
@@ -26,15 +24,6 @@ function ProfileForm() {
 	if (!userData) {
 		return <div>로딩 중...</div>;
 	}
-
-	/** user Data 가공 */
-	const profileData = Object.keys(userData)?.reduce((prev, curKey) => {
-		if (['name', 'email', 'companyName', 'image'].includes(curKey.toString())) {
-			prev[curKey as keyof ProfileHeaderProps] =
-				userData[curKey as keyof ProfileHeaderProps];
-		}
-		return prev;
-	}, {} as ProfileHeaderProps);
 
 	const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
@@ -46,19 +35,19 @@ function ProfileForm() {
 			<Dialog>
 				<Dialog.Content title='프로필 수정하기'>
 					<div className='flex flex-col gap-4 mb-[24px]'>
-						<ProfileInput image={profileData.image} />
+						<ProfileInput image={userData.image} />
 						<FormControl.InputControl
 							id='company'
 							title='회사'
 							name='companyName'
-							value={profileData.companyName}
+							value={userData.companyName}
 						/>
 						<FormControl.InputControl
 							id='email'
 							title='이메일'
 							name='email'
 							disabled={true}
-							value={profileData.email}
+							value={userData.email}
 						/>
 					</div>
 				</Dialog.Content>

--- a/src/app/(home)/mypage/components/ProfileHeader/ProfileHeader.tsx
+++ b/src/app/(home)/mypage/components/ProfileHeader/ProfileHeader.tsx
@@ -1,19 +1,28 @@
+'use client';
+
 import Link from 'next/link';
 import ProfileIcon from '../ProfileIcon/ProfileIcon';
 import Image from 'next/image';
 import type { IUser } from '@/types/userType';
+import { getUserData } from '@/api/getUserData';
+import { useEffect, useState } from 'react';
 
-export type ProfileHeaderProps = Pick<
-	IUser,
-	'name' | 'companyName' | 'image' | 'email'
->;
+function ProfileHeader() {
+	const [data, setData] = useState<IUser>();
+	const getData = async () => {
+		const userData = await getUserData();
+		setData(userData);
+	};
 
-function ProfileHeader({
-	name,
-	companyName,
-	image,
-	email,
-}: ProfileHeaderProps) {
+	useEffect(() => {
+		getData();
+	}, []);
+
+	if (!data) return;
+
+	const { name, email, companyName, image } = data;
+
+	/** zustand/reactQuery 로 변경할 예정 */
 	return (
 		<section className='border border-2 border-gray-200 rounded-3xl overflow-hidden'>
 			<div className='bg-orange-400 flex items-center justify-between pl-6 pr-4 py-4'>

--- a/src/app/(home)/mypage/page.tsx
+++ b/src/app/(home)/mypage/page.tsx
@@ -1,6 +1,3 @@
-/** profile Header prop 확인을 위해 임시 작성 */
-'use client';
-
 import ProgressBar from '@/components/ProgressBar/ProgressBar';
 import Badge from '@/components/Badge/Badge';
 import HeartRatings from '@/components/HeartRatings/HeartRatings';
@@ -12,7 +9,7 @@ import ProfileHeader from './components/ProfileHeader/ProfileHeader';
 import CardBase from './components/CardList/CardBase';
 import { getUserData } from '@/api/getUserData';
 import type { IUser } from '@/types/userType';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 export interface IMeeting {
 	teamId: number;
 	id: number;
@@ -110,20 +107,6 @@ function MyPage() {
 	};
 	// const userData: Promise<IUser> = getData();
 
-	/** profile Header prop 확인을 위해 임시 작성 */
-	useEffect(() => {
-		getData();
-	}, []);
-
-	/** user Data 가공 */
-	const profileData = Object.keys(userData)?.reduce((prev, curKey) => {
-		if (['name', 'email', 'companyName', 'image'].includes(curKey.toString())) {
-			prev[curKey as keyof ProfileHeaderProps] =
-				userData[curKey as keyof ProfileHeaderProps];
-		}
-		return prev;
-	}, {} as ProfileHeaderProps);
-
 	return (
 		<div>
 			<div className='flex flex-col gap-1 p-4'>
@@ -206,7 +189,7 @@ function MyPage() {
 			</div>
 			Profile
 			<div className='mx-[3rem]'>
-				<ProfileHeader {...profileData} />
+				<ProfileHeader />
 			</div>
 			<Link href={'/mypage/my-profile'}></Link>
 		</div>

--- a/src/app/(home)/mypage/page.tsx
+++ b/src/app/(home)/mypage/page.tsx
@@ -12,7 +12,6 @@ import ProfileHeader from './components/ProfileHeader/ProfileHeader';
 import CardBase from './components/CardList/CardBase';
 import { getUserData } from '@/api/getUserData';
 import type { IUser } from '@/types/userType';
-import type { ProfileHeaderProps } from './components/ProfileHeader/ProfileHeader';
 import { useEffect, useState } from 'react';
 export interface IMeeting {
 	teamId: number;

--- a/src/app/(home)/mypage/page.tsx
+++ b/src/app/(home)/mypage/page.tsx
@@ -7,9 +7,6 @@ import GlobalModal from './components/GlobalModal';
 import Button from '@/components/Button/Button';
 import ProfileHeader from './components/ProfileHeader/ProfileHeader';
 import CardBase from './components/CardList/CardBase';
-import { getUserData } from '@/api/getUserData';
-import type { IUser } from '@/types/userType';
-import { useState } from 'react';
 export interface IMeeting {
 	teamId: number;
 	id: number;
@@ -100,13 +97,6 @@ const mockMeetings: IMeeting[] = [
 ];
 
 function MyPage() {
-	const [userData, setUserData] = useState<IUser>({} as IUser);
-	const getData = async () => {
-		const data = await getUserData();
-		setUserData(data);
-	};
-	// const userData: Promise<IUser> = getData();
-
 	return (
 		<div>
 			<div className='flex flex-col gap-1 p-4'>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { createPortal } from 'react-dom';
 import Image from 'next/image';
 
-export default function Modal({
+export function Modal({
 	children,
 	isOpen,
 	noBackDrop,
@@ -16,6 +16,8 @@ export default function Modal({
 	noBackDrop?: boolean;
 	onClose?: () => void;
 }) {
+	// window
+	if (typeof window === 'undefined') return;
 	const router = useRouter();
 	const dialogRef = useRef<ComponentRef<'dialog'>>(null);
 

--- a/src/lib/ModalProvider.tsx
+++ b/src/lib/ModalProvider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ReactNode } from 'react';
-import Modal from '../components/Modal/Modal';
+import { Modal } from '../components/Modal/Modal';
 import useModalStore from './modalStore';
 
 export function ModalProvider({ children }: { children: ReactNode }) {


### PR DESCRIPTION
**개요**

- prop을 받아서 사용자 정보를 출력하던 `ProfileHeader` 컴포넌트를 클라이언트 렌더링으로 변경하였습니다

**타입**

- [x] ✨feat: 기능 추가, 수정, 삭제
- [ ] 🐛fix: 버그, 오류 수정
- [ ] ⚙️config: npm 모듈 설치 , 설정 파일 추가, 라이브러리 추가 등
- [ ] 🌱chore: 그 외 기타 변경 사항에 대한 커밋(기타변경, 오탈자 수정,네이밍 변경 등)으로 프로덕션 코드 변경X
- [ ] 📝docs: README.md, json 파일 등 수정 (문서 관련, 코드 수정 없음)
- [ ] 🎨style: 코드 스타일 및 포맷 / CSS 등 사용자 UI 디자인 변경 (제품 코드 수정 발생, 코드 형식, 정렬 등의 변경)
- [ ] ♻️refactor: 코드 리팩토링
- [ ] 🧪test: 테스트 코드 추가, 삭제, 변경 등 (코드 수정 없음, 테스트 코드에 관련된 모든 변경에 해당)
- [ ] 🗑️remove: 파일을 삭제하는 작업만 수행한 경우

**작업 사항**

- 클라이언트에서만 인증 유효성 검사가 가능한 현재 구조를 반영하여 `ProfileHeader` 컴포넌트 내부에서 유효성 검사 api 를 호출하도록 변경하였습니다
- 이후 전역 상태관리 값으로 받아오는 로직으로 변경 예정입니다
**Others - optional**

- 스크린샷이나 참고한 링크
