### PR TITLE
feat: pageNav, filtering에서 전역 상태 하나의 store로 관리 구현

### DIFF
--- a/src/app/(home)/_components/HomeFilter.tsx
+++ b/src/app/(home)/_components/HomeFilter.tsx
@@ -5,7 +5,7 @@ import { useFilterStore } from '@/store/useInputSelectFilterStore';
 import React, { useEffect } from 'react';
 
 export default function HomeFilter() {
-	const { selectedFilters, setSelectedFilters } = useFilterStore();
+	const { selectedFilters } = useFilterStore();
 
 	useEffect(() => {
 		//console.log('현재 필터 값:', selectedFilters);
@@ -16,8 +16,6 @@ export default function HomeFilter() {
 			<FilterList
 				// 사용 가능한 필터 선택
 				enabledFilters={['location', 'date', 'sortByReview']}
-				selectedFilters={selectedFilters}
-				onFilterChange={(filters) => setSelectedFilters(filters)}
 			/>
 		</div>
 	);

--- a/src/app/(home)/all-reviews/page.tsx
+++ b/src/app/(home)/all-reviews/page.tsx
@@ -9,10 +9,15 @@ import PageInfo from '@/components/PageInfo/PageInfo';
 import ReviewCard from '@/components/ReviewCard/ReviewCard';
 import { getReviewScore } from '@/api/getReveiwScore';
 import { useFetchReviews } from '@/hooks/customs/useFetchReviews';
+import { useFilterStore } from '@/store/useInputSelectFilterStore';
 
 export default function AllReviews() {
-	const [selectedFilters, setSelectedFilters] = useState({});
+	const { selectedFilters } = useFilterStore();
 	const [reviewScore, setReviewScore] = useState<ReviewScore[] | null>(null);
+
+	useEffect(() => {
+		console.log('현재 필터 값:', selectedFilters);
+	}, [selectedFilters]);
 
 	useFetchReviews();
 
@@ -37,17 +42,6 @@ export default function AllReviews() {
 				<FilterList
 					// 사용 가능한 필터 선택
 					enabledFilters={['location', 'date', 'sortByReview']}
-					selectedFilters={selectedFilters}
-					onFilterChange={(filters) =>
-						setSelectedFilters({
-							location: filters.location || '',
-							date: filters.date || '',
-							sortReview: filters.sortReview || {
-								sortBy: 'createdAt',
-								sortOrder: 'asc',
-							},
-						})
-					}
 				/>
 				<div>
 					<ReviewCard>

--- a/src/components/Filtering/Filter.tsx
+++ b/src/components/Filtering/Filter.tsx
@@ -15,7 +15,7 @@ interface FilterDropdownProps {
 	onToggle: () => void; // 부모에서 내려주는 `onToggle`
 }
 
-function Filter({
+function FilterDropdown({
 	category,
 	selected,
 	sortOrder = 'asc',
@@ -156,4 +156,4 @@ function Filter({
 	);
 }
 
-export default Filter;
+export default FilterDropdown;

--- a/src/components/PageNav/PageNavbar.tsx
+++ b/src/components/PageNav/PageNavbar.tsx
@@ -20,40 +20,53 @@ function PageNavbar({ pageKey, onMainClick, onSubClick }: NavBarProps) {
 
 	const { selectedFilters, setSelectedFilters } = useFilterStore();
 
+	// ✅ 현재 활성화된 메인 메뉴 상태
 	const [activeMainItem, setActiveMainItem] = useState<string>(
 		pageNavData[0]?.id || '',
 	);
 
-	// 현재 경로에서 mainId와 subId 추출 (mypage일 경우)
+	// ✅ 현재 경로에서 mainId와 subId 추출
 	const pathSegments = pathname.split('/');
 	const initialMainId = isMyPage
 		? pathSegments[2] || pageNavData[0]?.id
 		: pageNavData[0]?.id;
-	const initialSubId = isMyPage ? pathSegments[3] : 'DALLAEMFIT';
+	const initialSubId = isMyPage
+		? pathSegments[3]
+		: pageNavData.find((item) => item.id === initialMainId)?.subItems?.[0]?.id;
 
+	// ✅ 초기 상태 설정
 	useEffect(() => {
 		setActiveMainItem(initialMainId);
-		if (!selectedFilters.type) {
-			setSelectedFilters({ type: initialSubId ?? initialMainId });
-		}
-	}, [initialMainId, initialSubId, setSelectedFilters, selectedFilters.type]);
 
+		// ✅ 서브 아이템이 없는 경우 mainId를 type으로 강제 설정
+		if (!initialSubId) {
+			setSelectedFilters({ type: initialMainId });
+		} else {
+			setSelectedFilters({ type: initialSubId });
+		}
+	}, [initialMainId, initialSubId, setSelectedFilters]);
+
+	// ✅ 메인 버튼 클릭 핸들러
 	const handleMainClick = (id: string) => {
 		const selectedMainItem = pageNavData.find((item) => item.id === id);
-		const firstSubItem = selectedMainItem?.subItems?.[0]?.id || undefined;
+		const firstSubItem = selectedMainItem?.subItems?.[0]?.id;
 
-		setActiveMainItem(id);
-		// subItem이 있으면 subItem, 없으면 mainItem
+		// ✅ 서브 아이템이 없으면 무조건 mainItem을 적용
 		setSelectedFilters({ type: firstSubItem ?? id });
+
+		// ✅ 상태 업데이트 순서 최적화
+		setActiveMainItem(id);
+
 		onMainClick?.(id);
 	};
 
+	// ✅ 서브 버튼 클릭 핸들러
 	const handleSubClick = (id: string) => {
 		setSelectedFilters({ type: id });
 		onSubClick?.(id);
 	};
 
-	// 애니메이션을 위한 활성화 버튼 추적
+	// ✅ 애니메이션을 위한 활성화 버튼 추적
 	const mainNavRef = useRef<(HTMLButtonElement | null)[]>([]);
 	const [currentButton, setCurrentButton] = useState({ left: 0, width: 0 });
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -34,7 +34,7 @@ export const NAV_DATA: Record<string, PageNavData[]> = {
 			active: true,
 			subItems: [
 				// 해당 메인 아이템에 종속된 subItems
-				{ id: 'all', label: '전체', active: true },
+				{ id: 'DALLAEMFIT', label: '전체', active: true },
 				{
 					id: 'OFFICE_STRETCHING',
 					label: '오피스 스트레칭',

--- a/src/store/useInputSelectFilterStore.tsx
+++ b/src/store/useInputSelectFilterStore.tsx
@@ -2,12 +2,11 @@ import { create } from 'zustand';
 
 interface FilterState {
 	selectedFilters: {
+		type: string;
 		location: string;
 		date: string;
-		sortReview: {
-			sortBy: string;
-			sortOrder: 'asc' | 'desc';
-		};
+		sortBy: string;
+		sortOrder: string;
 	};
 	setSelectedFilters: (
 		filters: Partial<FilterState['selectedFilters']>,
@@ -16,12 +15,11 @@ interface FilterState {
 
 export const useFilterStore = create<FilterState>((set) => ({
 	selectedFilters: {
+		type: '',
 		location: '',
 		date: '',
-		sortReview: {
-			sortBy: 'createdAt',
-			sortOrder: 'asc',
-		},
+		sortBy: '',
+		sortOrder: 'asc',
 	},
 	setSelectedFilters: (filters) =>
 		set((state) => ({


### PR DESCRIPTION
**개요**
카드, 리뷰 api 호출 시 적용해야 할 파라미터 값을 pageNav+filtering 하나의 스토어에서 전역 상태 값으로 가져올 수 있게 되었습니다! 

**타입**

- [x] ✨feat: 기능 추가, 수정, 삭제
- [ ] 🐛fix: 버그, 오류 수정
- [ ] ⚙️config: npm 모듈 설치 , 설정 파일 추가, 라이브러리 추가 등
- [ ] 🌱chore: 그 외 기타 변경 사항에 대한 커밋(기타변경, 오탈자 수정,네이밍 변경 등)으로 프로덕션 코드 변경X
- [ ] 📝docs: README.md, json 파일 등 수정 (문서 관련, 코드 수정 없음)
- [ ] 🎨style: 코드 스타일 및 포맷 / CSS 등 사용자 UI 디자인 변경 (제품 코드 수정 발생, 코드 형식, 정렬 등의 변경)
- [ ] ♻️refactor: 코드 리팩토링
- [ ] 🧪test: 테스트 코드 추가, 삭제, 변경 등 (코드 수정 없음, 테스트 코드에 관련된 모든 변경에 해당)
- [ ] 🗑️remove: 파일을 삭제하는 작업만 수행한 경우

**작업 사항**
- 리뷰카드, 모임 카드의 필터링 내용을 하나의 zustand 스토어에서 관리하기 위해 useFilterStore를 만들었습니다.
- pageNav, filterList에서 useEffect을 사용해 스토어에 저장될 값들을 실시간으로 저장합니다.


**Others - optional**

- 스크린샷
![image](https://github.com/user-attachments/assets/2a7f11e2-2203-4ccf-bd55-4e56499e3d7e)

