### PR TITLE
feat: 마이페이지 - 프로필 회사명 수정 기능 추가

### DIFF
--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -4,7 +4,7 @@ const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 export const editProfile = async (data: FormData) => {
 	const token = localStorage.getItem('authToken');
 
-	const res = await fetch(`${BASE_URL}auths/user`, {
+	const res = await fetch(`${BASE_URL}/auths/user`, {
 		method: 'PUT',
 		headers: {
 			Authorization: `Bearer ${token}`,

--- a/src/app/(home)/mypage/components/ProfileForm/Input.tsx
+++ b/src/app/(home)/mypage/components/ProfileForm/Input.tsx
@@ -8,6 +8,7 @@ function Input({
 			{...props}
 			value={value}
 			className={`bg-transparent resize-none w-full h-full outline-none`}
+			onChange={onChange}
 		/>
 	);
 }

--- a/src/app/(home)/mypage/components/ProfileForm/ProfileForm.tsx
+++ b/src/app/(home)/mypage/components/ProfileForm/ProfileForm.tsx
@@ -12,16 +12,37 @@ import { useRouter } from 'next/navigation';
 
 function ProfileForm() {
 	const [userData, setUserData] = useState<IUser | null>();
-	const [companyName, setComapanyName] = useState<
-		IUser['companyName'] | string
-	>('');
+	const [formState, setFormState] = useState<Record<string, string>>({
+		image: '',
+		companyName: '',
+	});
+
+	// 폼 유효성 상태
+	const [isValid, setIsValid] = useState(false);
+
+	const handleFormChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+		// 이전 상태 값과 통합하여 유효성 검사(빈 값인지 비교)
+		const { name, value } = e.target;
+
+		// 상태 업데이트
+		setFormState((prevState) => ({
+			...prevState,
+			[name]: value,
+		}));
+	};
+
+	useEffect(() => {
+		// formState가 변경될 때마다 유효성 검사
+		const isValid = Object.values(formState).every((val) => val.trim() !== '');
+		setIsValid(isValid);
+	}, [formState]); // formState가 변경될 때마다 실행됨
 
 	const router = useRouter();
 
 	const getData = async () => {
 		const data = await getUserData();
 		setUserData(data);
-		setComapanyName(data?.companyName);
+		setFormState({ image: data?.image, companyName: data?.companyName });
 	};
 	// const userData: Promise<IUser> = getData();
 
@@ -33,7 +54,7 @@ function ProfileForm() {
 		return <div>로딩 중...</div>;
 	}
 
-	const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
 		const formData = new FormData(e.currentTarget);
 		const data = await editProfile(formData);
@@ -48,15 +69,16 @@ function ProfileForm() {
 			<Dialog>
 				<Dialog.Content title='프로필 수정하기'>
 					<div className='flex flex-col gap-4 mb-[24px]'>
-						<ProfileInput image={userData?.image} />
+						<ProfileInput
+							image={userData?.image}
+							onImageChange={handleFormChange}
+						/>
 						<FormControl.InputControl
 							id='company'
 							title='회사'
 							name='companyName'
-							value={companyName}
-							onChange={(e) => {
-								setComapanyName(e.target.value);
-							}}
+							value={formState.companyName}
+							onChange={handleFormChange}
 						/>
 						<FormControl.InputControl
 							id='email'
@@ -71,14 +93,16 @@ function ProfileForm() {
 				<Dialog.ButtonContainer>
 					<Button
 						state='default'
-						isOutlined={true}
+						variation='outline'
 						isFull={true}
-						onClick={() => {}}
+						onClick={() => {
+							router.back();
+						}}
 						type='button'
 					>
 						취소
 					</Button>
-					<Button isFull={true} disabled={false} type='submit'>
+					<Button isFull={true} disabled={!isValid} type='submit'>
 						수정 하기
 					</Button>
 				</Dialog.ButtonContainer>

--- a/src/app/(home)/mypage/components/ProfileForm/ProfileForm.tsx
+++ b/src/app/(home)/mypage/components/ProfileForm/ProfileForm.tsx
@@ -8,12 +8,20 @@ import { FormEvent, useEffect, useState } from 'react';
 import { editProfile } from '@/api/users';
 import { getUserData } from '@/api/getUserData';
 import type { IUser } from '@/types/userType';
+import { useRouter } from 'next/navigation';
 
 function ProfileForm() {
 	const [userData, setUserData] = useState<IUser | null>();
+	const [companyName, setComapanyName] = useState<
+		IUser['companyName'] | string
+	>('');
+
+	const router = useRouter();
+
 	const getData = async () => {
 		const data = await getUserData();
 		setUserData(data);
+		setComapanyName(data?.companyName);
 	};
 	// const userData: Promise<IUser> = getData();
 
@@ -29,6 +37,11 @@ function ProfileForm() {
 		e.preventDefault();
 		const formData = new FormData(e.currentTarget);
 		const data = await editProfile(formData);
+
+		if (data) {
+			// useMutation 으로 변경 예정
+			return router.back();
+		}
 	};
 	return (
 		<form onSubmit={handleSubmit}>
@@ -40,7 +53,10 @@ function ProfileForm() {
 							id='company'
 							title='회사'
 							name='companyName'
-							value={userData?.companyName}
+							value={companyName}
+							onChange={(e) => {
+								setComapanyName(e.target.value);
+							}}
 						/>
 						<FormControl.InputControl
 							id='email'
@@ -48,6 +64,7 @@ function ProfileForm() {
 							name='email'
 							disabled={true}
 							value={userData?.email}
+							readOnly={true}
 						/>
 					</div>
 				</Dialog.Content>

--- a/src/app/(home)/mypage/components/ProfileInput/ProfileInput.tsx
+++ b/src/app/(home)/mypage/components/ProfileInput/ProfileInput.tsx
@@ -1,8 +1,14 @@
-import { ChangeEvent, useEffect, useState } from 'react';
+import { ChangeEvent, FormEvent, useEffect, useState } from 'react';
 import ProfileIcon from '../ProfileIcon/ProfileIcon';
 import Image from 'next/image';
 
-function ProfileInput({ image }: { image: string }) {
+function ProfileInput({
+	image,
+	onImageChange,
+}: {
+	image: string;
+	onImageChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+}) {
 	const [preview, setPreview] = useState<string | null | FileReader['result']>(
 		image,
 	);
@@ -40,6 +46,11 @@ function ProfileInput({ image }: { image: string }) {
 			setPreview(previewSrc);
 		} else {
 			setPreview(null);
+		}
+
+		// form valid 검사를 위한 연결
+		if (typeof onImageChange === 'function') {
+			onImageChange(e);
 		}
 	};
 	return (


### PR DESCRIPTION
**개요**

- 프로필에서 회사명을 수정 기능을 추가하였습니다

**타입**

- [x] ✨feat: 기능 추가, 수정, 삭제
- [ ] 🐛fix: 버그, 오류 수정
- [ ] ⚙️config: npm 모듈 설치 , 설정 파일 추가, 라이브러리 추가 등
- [ ] 🌱chore: 그 외 기타 변경 사항에 대한 커밋(기타변경, 오탈자 수정,네이밍 변경 등)으로 프로덕션 코드 변경X
- [ ] 📝docs: README.md, json 파일 등 수정 (문서 관련, 코드 수정 없음)
- [ ] 🎨style: 코드 스타일 및 포맷 / CSS 등 사용자 UI 디자인 변경 (제품 코드 수정 발생, 코드 형식, 정렬 등의 변경)
- [ ] ♻️refactor: 코드 리팩토링
- [ ] 🧪test: 테스트 코드 추가, 삭제, 변경 등 (코드 수정 없음, 테스트 코드에 관련된 모든 변경에 해당)
- [ ] 🗑️remove: 파일을 삭제하는 작업만 수행한 경우

**작업 사항**

- `.env` 파일의 BASE_URL 변경을 반영하여 api endpoint를 수정하였습니다
- 마이페이지의 프로필 수정 버튼을 눌러 프로필 수정 기능을 추가하였습니다
- 프로필의 회사명이 빈 값인 경우 버튼이 활성화되지 않도록 하였습니다
- 남은 할 일
  - 프로필 수정 후 새로고침 되지 않는 현상 --> react query useMutation 적용하여 쿼리 key refetch 요청으로 변경 예정

**Others - optional**

- 스크린샷이나 참고한 링크
- 
![-Chrome2025-02-2413-14-03-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/2f33952f-10a6-4f43-bd4c-9b0c80fb070e)

