### PR TITLE
feat: filtering state 관련 Context API 추가 및 기존 코드 Context API에 맞게 변경

### DIFF
--- a/src/app/(home)/_components/HomeFilter.tsx
+++ b/src/app/(home)/_components/HomeFilter.tsx
@@ -1,15 +1,17 @@
 'use client';
 
 import FilterList from '@/components/Filtering/FIlterList';
-import { useFilterStore } from '@/store/useInputSelectFilterStore';
+import { useFilter } from '@/hooks/customs/useFilter';
+//import { useFilterStore } from '@/store/useInputSelectFilterStore';
 import React, { useEffect } from 'react';
 
 export default function HomeFilter() {
-	const { selectedFilters } = useFilterStore();
+	//const { selectedFilters } = useFilterStore();
+	const { type, location, date, sortBy, sortOrder } = useFilter();
 
 	useEffect(() => {
-		//console.log('현재 필터 값:', selectedFilters);
-	}, [selectedFilters]);
+		console.log('현재 필터 값:', type, location, date, sortBy, sortOrder);
+	}, [type, location, date, sortBy, sortOrder]);
 
 	return (
 		<div>

--- a/src/app/(home)/all-reviews/page.tsx
+++ b/src/app/(home)/all-reviews/page.tsx
@@ -7,13 +7,24 @@ import { useFetchReviews } from '@/hooks/customs/useFetchReviews';
 import ReviewCardList from './_components/ReviewCardList';
 import useFetchReviewScores from '@/hooks/query/useFetchReviewsScore';
 import ReviewSummary from './_components/ReviewSummary';
+import FilterProvider from '@/context/FilterContent';
 
 export default function AllReviews() {
+	return (
+		<div className='flex flex-col gap-6'>
+			<FilterProvider>
+				<ReviewsSection />
+			</FilterProvider>
+		</div>
+	);
+}
+
+function ReviewsSection() {
 	const reviews = useFetchReviews();
 	const reviewsScore = useFetchReviewScores({ gatheringId: '' });
 
 	return (
-		<div className='flex flex-col gap-6'>
+		<>
 			<div className='flex flex-col gap-3 pb-4 border-b-2 border-gray-200 '>
 				<PageInfo pageKey='reviews' />
 				<PageNavbar pageKey='meetings' />
@@ -23,6 +34,6 @@ export default function AllReviews() {
 				<FilterList enabledFilters={['location', 'date', 'sortByReview']} />
 				<ReviewCardList reviews={reviews} />
 			</div>
-		</div>
+		</>
 	);
 }

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -4,6 +4,7 @@ import PageInfo from '@/components/PageInfo/PageInfo';
 import PageNavbar from '@/components/PageNav/PageNavbar';
 import HomeFilter from './_components/HomeFilter';
 import HomeButton from './_components/HomeButton';
+import FilterProvider from '@/context/FilterContent';
 
 export default async function Home() {
 	return (
@@ -11,22 +12,24 @@ export default async function Home() {
 			{/* 함께 할 사람이 없나요? */}
 			<PageInfo pageKey='meetings' />
 
-			{/* 필터 드롭다운 메뉴  */}
-			<HomeFilter />
+			<FilterProvider>
+				{/* 필터 드롭다운 메뉴  */}
+				<HomeFilter />
 
-			{/* 달램핏 nav 및 filter 및 모임 만들기 */}
-			<div className='flex relative mt-10 mb-5'>
-				<PageNavbar pageKey='meetings' />
-				<div className='absolute right-0'>
-					<HomeButton />
+				{/* 달램핏 nav 및 filter 및 모임 만들기 */}
+				<div className='flex relative mt-10 mb-5'>
+					<PageNavbar pageKey='meetings' />
+					<div className='absolute right-0'>
+						<HomeButton />
+					</div>
 				</div>
-			</div>
 
-			{/* 보더 콘테이너 */}
-			<div className='border-b-2'></div>
+				{/* 보더 콘테이너 */}
+				<div className='border-b-2'></div>
 
-			{/* 모임 목록 */}
-			<CardList />
+				{/* 모임 목록 */}
+				<CardList />
+			</FilterProvider>
 		</div>
 	);
 }

--- a/src/components/Filtering/FIlterList.tsx
+++ b/src/components/Filtering/FIlterList.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import { FITERING_DATA } from '@/constants';
 import FilterDropdown from '@/components/Filtering/Filter';
 import CalenderFilter from '../Calendar/CalendarFilter';
-import { useFilterStore } from '@/store/useInputSelectFilterStore';
+import { useFilter } from '@/hooks/customs/useFilter';
 
 interface FilterListProps {
 	enabledFilters?: ('location' | 'date' | 'sortByMeeting' | 'sortByReview')[];
@@ -13,13 +13,22 @@ interface FilterListProps {
 export default function FilterList({
 	enabledFilters = ['location', 'date', 'sortByMeeting', 'sortByReview'],
 }: FilterListProps) {
-	const { selectedFilters, setSelectedFilters } = useFilterStore();
+	const {
+		location,
+		setLocation,
+		date,
+		setDate,
+		sortBy,
+		setSortBy,
+		sortOrder,
+		setSortOrder,
+	} = useFilter();
 
 	const [selectedLocation, setSelectedLocation] = useState(
-		selectedFilters.location || FITERING_DATA.location[0].value,
+		location || FITERING_DATA.location[0].value,
 	);
 	const [selectedDate, setSelectedDate] = useState<Date | null>(
-		selectedFilters.date ? new Date(selectedFilters.date) : null,
+		date ? new Date(date) : null,
 	);
 	const formattedDate = selectedDate?.toISOString().split('T')[0] ?? '';
 
@@ -27,12 +36,9 @@ export default function FilterList({
 		? FITERING_DATA.sortByReview[0].value
 		: FITERING_DATA.sortByMeeting[0].value;
 
-	const [selectedSortBy, setSelectedSortBy] = useState(
-		selectedFilters.sortBy || initialSortBy,
-	);
-
+	const [selectedSortBy, setSelectedSortBy] = useState(sortBy || initialSortBy);
 	const [selectedSortOrder, setSelectedSortOrder] = useState(
-		selectedFilters.sortOrder || 'asc',
+		sortOrder || 'desc',
 	);
 
 	// 현재 열린 드롭다운 ID 관리 (하나만 열리도록)
@@ -42,24 +48,22 @@ export default function FilterList({
 		setIsOpenDropdown((prev) => (prev === dropdownId ? null : dropdownId));
 	};
 
-	// 필터 값이 변경될 때 Zustand Store에 저장
 	useEffect(() => {
-		const updatedFilters = {
-			location: enabledFilters.includes('location') ? selectedLocation : '',
-			date: enabledFilters.includes('date') ? formattedDate : '',
-			sortBy:
-				enabledFilters.includes('sortByMeeting') ||
+		// 상태를 Context API를 통해 동기화
+		setLocation(enabledFilters.includes('location') ? selectedLocation : '');
+		setDate(enabledFilters.includes('date') ? formattedDate : '');
+		setSortBy(
+			enabledFilters.includes('sortByMeeting') ||
 				enabledFilters.includes('sortByReview')
-					? selectedSortBy
-					: '',
-			sortOrder:
-				enabledFilters.includes('sortByMeeting') ||
+				? selectedSortBy
+				: '',
+		);
+		setSortOrder(
+			enabledFilters.includes('sortByMeeting') ||
 				enabledFilters.includes('sortByReview')
-					? selectedSortOrder
-					: 'asc',
-		};
-
-		setSelectedFilters(updatedFilters);
+				? selectedSortOrder
+				: 'desc',
+		);
 	}, [selectedLocation, formattedDate, selectedSortBy, selectedSortOrder]);
 
 	return (

--- a/src/context/FilterContent.tsx
+++ b/src/context/FilterContent.tsx
@@ -2,14 +2,28 @@
 import { FilterContextType } from '@/types/filterType';
 import { createContext, useState, ReactNode } from 'react';
 
-export const FilterContext = createContext<FilterContextType | null>(null);
+const initialFilterContext: FilterContextType = {
+	type: 'DALLAEMFIT',
+	location: '',
+	date: '',
+	sortBy: '',
+	sortOrder: 'desc',
+	setType: () => {},
+	setLocation: () => {},
+	setDate: () => {},
+	setSortBy: () => {},
+	setSortOrder: () => {},
+};
+
+export const FilterContext =
+	createContext<FilterContextType>(initialFilterContext);
 
 const FilterProvider = ({ children }: { children: ReactNode }) => {
-	const [type, setType] = useState('DALLAEMFIT');
-	const [location, setLocation] = useState('');
-	const [date, setDate] = useState('');
-	const [sortBy, setSortBy] = useState('createdAt');
-	const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+	const [type, setType] = useState(initialFilterContext.type);
+	const [location, setLocation] = useState(initialFilterContext.location);
+	const [date, setDate] = useState(initialFilterContext.date);
+	const [sortBy, setSortBy] = useState(initialFilterContext.sortBy);
+	const [sortOrder, setSortOrder] = useState(initialFilterContext.sortOrder);
 
 	return (
 		<FilterContext.Provider

--- a/src/context/FilterContent.tsx
+++ b/src/context/FilterContent.tsx
@@ -1,0 +1,34 @@
+'use client';
+import { FilterContextType } from '@/types/filterType';
+import { createContext, useState, ReactNode } from 'react';
+
+export const FilterContext = createContext<FilterContextType | null>(null);
+
+const FilterProvider = ({ children }: { children: ReactNode }) => {
+	const [type, setType] = useState('DALLAEMFIT');
+	const [location, setLocation] = useState('');
+	const [date, setDate] = useState('');
+	const [sortBy, setSortBy] = useState('createdAt');
+	const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+
+	return (
+		<FilterContext.Provider
+			value={{
+				type,
+				location,
+				date,
+				sortBy,
+				sortOrder,
+				setType,
+				setLocation,
+				setDate,
+				setSortBy,
+				setSortOrder,
+			}}
+		>
+			{children}
+		</FilterContext.Provider>
+	);
+};
+
+export default FilterProvider;

--- a/src/hooks/customs/useFetchReviews.tsx
+++ b/src/hooks/customs/useFetchReviews.tsx
@@ -1,28 +1,28 @@
 import { reviewService } from '@/service/reviewService';
-import { useFilterStore } from '@/store/useInputSelectFilterStore';
 import { useEffect, useState } from 'react';
+import { useFilter } from './useFilter';
 
 export const useFetchReviews = () => {
 	const [reviews, setReviews] = useState([]);
-	const { selectedFilters } = useFilterStore();
+	const { type, location, date, sortBy, sortOrder } = useFilter();
 
 	const fetchReviews = async () => {
 		const params = new URLSearchParams();
 		try {
-			if (selectedFilters.type) {
-				params.append('type', selectedFilters.type);
+			if (type) {
+				params.append('type', type);
 			}
-			if (selectedFilters.location) {
-				params.append('location', selectedFilters.location);
+			if (location) {
+				params.append('location', location);
 			}
-			if (selectedFilters.date) {
-				params.append('date', selectedFilters.date);
+			if (date) {
+				params.append('date', date);
 			}
-			if (selectedFilters.sortBy) {
-				params.append('sortBy', selectedFilters.sortBy);
+			if (sortBy) {
+				params.append('sortBy', sortBy);
 			}
-			if (selectedFilters.sortOrder) {
-				params.append('sortOrder', selectedFilters.sortOrder);
+			if (sortOrder) {
+				params.append('sortOrder', sortOrder);
 			}
 
 			const data = await reviewService.getDetailReviewData({
@@ -37,10 +37,8 @@ export const useFetchReviews = () => {
 	};
 
 	useEffect(() => {
-		if (selectedFilters) {
-			fetchReviews();
-		}
-	}, [selectedFilters]);
+		fetchReviews();
+	}, [type, location, date, sortBy, sortOrder]);
 
 	return reviews;
 };

--- a/src/hooks/customs/useFilter.tsx
+++ b/src/hooks/customs/useFilter.tsx
@@ -1,0 +1,8 @@
+import { FilterContext } from '@/context/FilterContent';
+import { useContext } from 'react';
+
+export const useFilter = () => {
+	const context = useContext(FilterContext);
+
+	return context;
+};

--- a/src/hooks/query/useFetchReviewsScore.tsx
+++ b/src/hooks/query/useFetchReviewsScore.tsx
@@ -1,15 +1,11 @@
 import { getReviewScore } from '@/api/getReveiwScore';
-import { useFilterStore } from '@/store/useInputSelectFilterStore';
-import { GetReviewsParams, ReviewScore } from '@/types/reviewType';
+import { ReviewScore } from '@/types/reviewType';
 import { useQuery } from '@tanstack/react-query';
+import { useFilter } from '../customs/useFilter';
+import { FilterContextType } from '@/types/filterType';
 
-function useFetchReviewScores({ gatheringId }: GetReviewsParams) {
-	const type = useFilterStore((state) => state.selectedFilters.type) as
-		| 'DALLAEMFIT'
-		| 'OFFICE_STRETCHING'
-		| 'MINDFULNESS'
-		| 'WORKATION';
-
+function useFetchReviewScores({ gatheringId }: { gatheringId: string }) {
+	const { type } = useFilter() as FilterContextType;
 	const { data, isLoading, error } = useQuery<ReviewScore, Error>({
 		queryKey: ['reviewScores', type],
 		queryFn: () => getReviewScore({ gatheringId, type }),

--- a/src/types/filterType.ts
+++ b/src/types/filterType.ts
@@ -1,0 +1,12 @@
+export interface FilterContextType {
+	type?: string;
+	location?: string;
+	date?: string;
+	sortBy?: string;
+	sortOrder?: 'asc' | 'desc';
+	setType: (type: string) => void;
+	setLocation: (location: string) => void;
+	setDate: (date: string) => void;
+	setSortBy: (sortBy: string) => void;
+	setSortOrder: (sortOrder: 'asc' | 'desc') => void;
+}

--- a/src/types/reviewType.ts
+++ b/src/types/reviewType.ts
@@ -12,7 +12,7 @@ export interface ReviewScore {
 
 export interface GetReviewsParams {
 	gatheringId?: string;
-	type?: '' | 'DALLAEMFIT' | 'OFFICE_STRETCHING' | 'MINDFULNESS' | 'WORKATION';
+	type?: string;
 }
 
 export interface ReviewQueryType {
@@ -20,7 +20,7 @@ export interface ReviewQueryType {
 	limit?: number;
 	currentPage?: number;
 	userId?: number;
-	type?: '' | 'DALLAEMFIT' | 'OFFICE_STRETCHING' | 'MINDFULNESS' | 'WORKATION';
+	type?: string;
 	location?: '건대입구' | '을지로 3가' | '신림' | '홍대입구' | '';
 	registrationEnd?: string;
 	date?: string;


### PR DESCRIPTION
**개요**
필터링 상태를 전역으로 관리하던 zustand를 쓰지않고, context API를 추가했습니다.

**타입**

- [x] ✨feat: 기능 추가, 수정, 삭제
- [ ] 🐛fix: 버그, 오류 수정
- [ ] ⚙️config: npm 모듈 설치 , 설정 파일 추가, 라이브러리 추가 등
- [ ] 🌱chore: 그 외 기타 변경 사항에 대한 커밋(기타변경, 오탈자 수정,네이밍 변경 등)으로 프로덕션 코드 변경X
- [ ] 📝docs: README.md, json 파일 등 수정 (문서 관련, 코드 수정 없음)
- [ ] 🎨style: 코드 스타일 및 포맷 / CSS 등 사용자 UI 디자인 변경 (제품 코드 수정 발생, 코드 형식, 정렬 등의 변경)
- [x] ♻️refactor: 코드 리팩토링
- [ ] 🧪test: 테스트 코드 추가, 삭제, 변경 등 (코드 수정 없음, 테스트 코드에 관련된 모든 변경에 해당)
- [ ] 🗑️remove: 파일을 삭제하는 작업만 수행한 경우

**작업 사항**
- 페이지 별 전역 상태가 관리 가능한 Context API를 추가했습니다. (추후 zustand 관련 코드를 삭제할 예정입니다.)
- 기존 코드에서 Zustand 스토어에서 가져온 값들을  Context API을 이용한 custom Hook(useFilter)로 가져오는 것으로 변경했습니다.
-  Context API 관련 타입 파일(FilterContextType )을 추가했습니다.
- GetReviewsParams과  ReviewQueryType의 타입을 
type?: '' | 'DALLAEMFIT' | 'OFFICE_STRETCHING' | 'MINDFULNESS' | 'WORKATION'; 애서 확장성을 위해  string으로 변경하였습니다.

- 스크린샷
![image](https://github.com/user-attachments/assets/bffe879e-a9b5-4995-9099-ac7af7e259cc)
