### PR TITLE
feat: 찜한 모임 카드리스트 hook 분리

### DIFF
--- a/src/app/(home)/favorite-meetings/components/CardList/CardList.tsx
+++ b/src/app/(home)/favorite-meetings/components/CardList/CardList.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { DateBadge } from '@/components/Badge/DateBadge';
+import { DeadlineBadge } from '@/components/Badge/DeadlineBadge';
+import { StatusBadge } from '@/components/Badge/StatusBadge';
+import { LikeButton } from '@/components/Button/LikeButton';
+import Card from '@/components/MainCard/Card';
+import Members from '@/components/Members/Members';
+import ProgressBar from '@/components/ProgressBar/ProgressBar';
+import { useFavoriteMeetings } from '@/hooks/customs/useFavoriteMeetings';
+import { useRouter } from 'next/navigation';
+
+function CardList() {
+	const { meetings, isLoading, error, deleteLikeMeetings } =
+		useFavoriteMeetings();
+	const router = useRouter();
+
+	return (
+		<div className='flex flex-col items-center gap-6'>
+			{meetings?.map((el) => (
+				<Card
+					id={el.id}
+					key={el.id ?? 0}
+					registrationEnd={new Date(el.registrationEnd) < new Date()}
+				>
+					<Card.ImageContainer>
+						<Card.ImageSection
+							src={el.image ? el.image : '/images/default.png'}
+							alt='이미지 예시'
+						/>
+						<DeadlineBadge
+							registrationEnd={
+								el.registrationEnd
+									? new Date(el.registrationEnd).toISOString()
+									: '유효하지 않은 시간'
+							}
+						/>
+					</Card.ImageContainer>
+
+					<Card.Content>
+						<Card.Header>
+							<Card.Header.Left
+								title={
+									el.type === 'OFFICE_STRETCHING'
+										? '달램핏 마인드풀니스 |'
+										: el.type === 'MINDFULNESS'
+											? '달램핏 마인드풀니스 |'
+											: el.type === 'WORKATION'
+												? '워크에이션 리프레쉬 |'
+												: ''
+								}
+								place={el.location}
+							>
+								<DateBadge
+									text={
+										el.dateTime && !isNaN(new Date(el.dateTime).getTime())
+											? new Date(el.dateTime).toLocaleDateString('ko-KR')
+											: ''
+									}
+									type='date'
+								/>
+
+								<DateBadge
+									text={
+										el.registrationEnd
+											? new Date(el.registrationEnd).toISOString()
+											: '유효하지 않은 시간'
+									}
+									type='time'
+								/>
+							</Card.Header.Left>
+
+							<Card.Header.Right>
+								<LikeButton itemId={el.id ?? 0} />
+							</Card.Header.Right>
+						</Card.Header>
+
+						<Card.Footer
+							max={40}
+							value={30}
+							onClick={() => {
+								router.push(`meeting/${el.id}`);
+							}}
+						>
+							<div className='flex gap-2'>
+								<Members max={el.capacity ?? 0} value={el.participantCount} />
+								<StatusBadge />
+							</div>
+							<ProgressBar
+								max={el.capacity}
+								value={el.participantCount}
+								isNeutral={false}
+								isAnimate={false}
+							/>
+						</Card.Footer>
+					</Card.Content>
+				</Card>
+			))}
+		</div>
+	);
+}
+
+export default CardList;

--- a/src/app/(home)/favorite-meetings/page.tsx
+++ b/src/app/(home)/favorite-meetings/page.tsx
@@ -1,5 +1,5 @@
-import CardList from '@/components/MainCard/CardList';
+import CardList from './components/CardList/CardList';
 
 export default function FavoriteMeetingPage() {
-	return <CardList meetingType='favorite' />;
+	return <CardList />;
 }

--- a/src/hooks/customs/useFavoriteMeetings.tsx
+++ b/src/hooks/customs/useFavoriteMeetings.tsx
@@ -1,0 +1,72 @@
+import { useQuery } from '@tanstack/react-query';
+import { meetingService } from '@/app/(home)/favorite-meetings/meetingService';
+import { useState } from 'react';
+import { useAuthStore } from '@/store/useAuthStore';
+import { IMeeting } from '@/types/meetingsType';
+
+export const useFavoriteMeetings = () => {
+	// 로컬 스토리지에서 찜한 아이디 목록 가져오기
+	function getLocalStorageItem<T>(key: string, defaultValue: T): T {
+		try {
+			const storedValue = localStorage.getItem(key);
+			if (storedValue) {
+				return JSON.parse(storedValue) as T;
+			} else {
+				return defaultValue;
+			}
+		} catch (error) {
+			console.error(
+				`Error parsing JSON from localStorage for key "${key}":`,
+				error,
+			);
+			return defaultValue;
+		}
+	}
+
+	const [filteredMeetings, setFilteredMeetings] = useState<IMeeting[]>([]);
+	const { userId, isLoggedIn, hasHydrated } = useAuthStore();
+
+	// 데이터 가져오는 함수
+	const getData = async () => {
+		console.log(
+			'로컬에서 가져온 userId값 있음?',
+			'ID값: ',
+			userId,
+			hasHydrated,
+		);
+
+		// 로그인한 유저 가져오기 전에는 api 호출하지 않음
+		if (!hasHydrated) {
+			return [];
+		}
+
+		// 아이디 목록을 기준으로 API 호출
+		const res = await meetingService.getFavoriteMeetings({
+			userId,
+			isLoggedIn,
+			// 나중에 필터 추가
+		});
+		return setFilteredMeetings(res);
+	};
+
+	// React Query로 서버에서 모임 데이터 가져오기
+	const { data, isLoading, error } = useQuery({
+		queryKey: userId ? ['favorite', userId] : [], // userId가 있을 때만 쿼리 키 설정
+		queryFn: getData,
+	});
+
+	const deleteLikeMeetings = () => {
+		setFilteredMeetings(() => {
+			return filteredMeetings?.filter((item) => {
+				[1000].includes(item.id);
+			});
+		});
+	};
+
+	return {
+		meetings: filteredMeetings,
+		isLoading,
+		error,
+		deleteLikeMeetings,
+	};
+};


### PR DESCRIPTION
**개요**

- 모임 찾기의 카드리스트와 공통화하여 사용하던 custom hook을 분리하였습니다

**타입**

- [x] ✨feat: 기능 추가, 수정, 삭제
- [ ] 🐛fix: 버그, 오류 수정
- [ ] ⚙️config: npm 모듈 설치 , 설정 파일 추가, 라이브러리 추가 등
- [ ] 🌱chore: 그 외 기타 변경 사항에 대한 커밋(기타변경, 오탈자 수정,네이밍 변경 등)으로 프로덕션 코드 변경X
- [ ] 📝docs: README.md, json 파일 등 수정 (문서 관련, 코드 수정 없음)
- [ ] 🎨style: 코드 스타일 및 포맷 / CSS 등 사용자 UI 디자인 변경 (제품 코드 수정 발생, 코드 형식, 정렬 등의 변경)
- [ ] ♻️refactor: 코드 리팩토링
- [ ] 🧪test: 테스트 코드 추가, 삭제, 변경 등 (코드 수정 없음, 테스트 코드에 관련된 모든 변경에 해당)
- [ ] 🗑️remove: 파일을 삭제하는 작업만 수행한 경우

**작업 사항**

- `useFavoriteMettings` custom hook을 추가하였습니다
- `useFavoriteMettings` hook 은
  1. 로컬 스토리지의 찜한 모임 id 를 기반으로 모임 정보를 fetch합니다
  2. 찜하기를 취소하면 클라이언트에서 필터링하여 해당 모임 정보를 삭제합니다
 - 남은 할 일
   - 로컬 스토리지에서 찜한 id 가져오는 로직 공통화하기
   - 찜 버튼 클릭/해제 시 핸들러 적용

**Others - optional**

- 스크린샷이나 참고한 링크
