### PR TITLE
feat: 찜한 모임 알림 뱃지 상태 관리 useNotificationStore 추가

### DIFF
--- a/src/hooks/customs/useLikeNotify.tsx
+++ b/src/hooks/customs/useLikeNotify.tsx
@@ -1,0 +1,81 @@
+import { useAuthStore } from '@/store/useAuthStore';
+import useNotificationStore from '@/store/useNotificationStore';
+import { useCallback } from 'react';
+
+// 로컬 스토리지에서 값을 가져오는 함수
+/** utils로 변경 예정 */
+function getLocalStorageItem<T>(key: string, defaultValue: T): T {
+	try {
+		const storedValue = localStorage.getItem(key);
+		if (storedValue) {
+			return JSON.parse(storedValue) as T;
+		} else {
+			return defaultValue;
+		}
+	} catch (error) {
+		console.error(
+			`Error parsing JSON from localStorage for key "${key}":`,
+			error,
+		);
+		return defaultValue;
+	}
+}
+
+/** 로그인한 사용자 또는 guest ID를 반환하는 함수 */
+/** utils로 변경 예정 */
+function getLikerKey({
+	likeList,
+	user,
+	isLoggedIn,
+}: {
+	likeList: ILikeListJSON;
+	user: number | null;
+	isLoggedIn: boolean;
+}) {
+	return Object.keys(likeList).find((key) => {
+		if (!(user && isLoggedIn)) {
+			// 로그인되지 않은 경우 guestId를 사용
+			const guestId = getLocalStorageItem<string>('guestId', '');
+			return Number(key) === Number(guestId);
+		}
+		return Number(key) === Number(user);
+	});
+}
+
+interface ILikeListJSON {
+	[key: string]: number[] | string[];
+}
+
+export const useLikeNotify = () => {
+	const hasHydrated = useAuthStore((state) => state.hasHydrated);
+	const userId = useAuthStore((state) => state.userId);
+	const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+
+	const updateNotification = useNotificationStore(
+		(state) => state.updateNotification,
+	);
+	const pageKey = 'favorite-meetings';
+
+	// likeList는 최신 상태 유지
+	const likeList = getLocalStorageItem<ILikeListJSON>('likes', {});
+
+	const likerKey = hasHydrated
+		? getLikerKey({ likeList, user: userId, isLoggedIn })
+		: null;
+
+	// 최신 localStorage 값을 가져오는 onChangeLike
+	const onChangeLike = useCallback(() => {
+		const latestLikeList = getLocalStorageItem<
+			Record<string, number[] | string[]>
+		>('likes', {});
+
+		if (!likerKey) {
+			return;
+		}
+
+		const count = latestLikeList[likerKey]?.length ?? 0;
+		updateNotification(pageKey, count > 0, count);
+	}, [likerKey, updateNotification, pageKey]);
+
+	return { onChangeLike };
+};

--- a/src/store/useNotificationStore.tsx
+++ b/src/store/useNotificationStore.tsx
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+
+interface NotificationState {
+	notifications: Record<string, { hasNotification: boolean; count: number }>;
+	updateNotification: (
+		key: string,
+		hasNotification: boolean,
+		count?: number,
+	) => void;
+}
+
+const useNotificationStore = create<NotificationState>((set) => ({
+	notifications: {
+		'favorite-meetings': { hasNotification: false, count: 0 },
+	},
+
+	updateNotification: (key, hasNotification, count = 0) => {
+		// console.log('updateNotification 실행: ', count);
+		set((state) => ({
+			notifications: {
+				...state.notifications,
+				[key]: { hasNotification, count },
+			},
+		}));
+	},
+}));
+
+export default useNotificationStore;


### PR DESCRIPTION
**개요**

- 찜한 모임 알림 뱃지 전역 상태 관리를 추가하였습니다

**타입**

- [x] ✨feat: 기능 추가, 수정, 삭제
- [ ] 🐛fix: 버그, 오류 수정
- [ ] ⚙️config: npm 모듈 설치 , 설정 파일 추가, 라이브러리 추가 등
- [ ] 🌱chore: 그 외 기타 변경 사항에 대한 커밋(기타변경, 오탈자 수정,네이밍 변경 등)으로 프로덕션 코드 변경X
- [ ] 📝docs: README.md, json 파일 등 수정 (문서 관련, 코드 수정 없음)
- [ ] 🎨style: 코드 스타일 및 포맷 / CSS 등 사용자 UI 디자인 변경 (제품 코드 수정 발생, 코드 형식, 정렬 등의 변경)
- [ ] ♻️refactor: 코드 리팩토링
- [ ] 🧪test: 테스트 코드 추가, 삭제, 변경 등 (코드 수정 없음, 테스트 코드에 관련된 모든 변경에 해당)
- [ ] 🗑️remove: 파일을 삭제하는 작업만 수행한 경우

**작업 사항**

- 알림 뱃지를 전역으로 관리할 수 있게 `useNotificationStore` 전역 상태 변수를 추가하였습니다
- 찜하기와 관련된 알림 상태를 관리할 수 있도록 `useLikeNotify` 커스텀 hook 을 추가하였습니다
- 남은 할 일
  - 찜하기 버튼 컴포넌트와 동기화하기
  - GNB 컴포넌트에서 찜하기 알림 상태 표시하기

**Others - optional**

- 스크린샷이나 참고한 링크
