### PR TITLE
feat: 마이페이지 모임 참여 취소 기능 추가

### DIFF
--- a/src/app/(home)/mypage/components/CardList/CardBase.tsx
+++ b/src/app/(home)/mypage/components/CardList/CardBase.tsx
@@ -87,11 +87,7 @@ function JoinedMeetingCard({
 	...props
 }: Partial<MeetingCardInfoProps & TagProps>) {
 	const CreateReviewButton = dynamic(() => import('./CreateReviewButton'), {
-		loading: () => (
-			<Button state='default' isOutlined={false}>
-				리뷰 작성하기
-			</Button>
-		),
+		loading: () => <Button>리뷰 작성하기</Button>,
 		ssr: !!false,
 	});
 
@@ -107,11 +103,7 @@ function JoinedMeetingCard({
 				<CardInfo {...(props as MeetingCardInfoProps)} />
 			</div>
 			{!!isDone && <CreateReviewButton />}
-			{!isDone && (
-				<Button state='default' isOutlined={true}>
-					예약 취소하기
-				</Button>
-			)}
+			{!isDone && <Button>예약 취소하기</Button>}
 		</div>
 	);
 }

--- a/src/app/(home)/mypage/components/CardList/CardBase.tsx
+++ b/src/app/(home)/mypage/components/CardList/CardBase.tsx
@@ -55,6 +55,7 @@ function CardBase({
 }) {
 	// 데이터를 가공한다(가공되는 데이터는 title, ...등등 클라이언트의 key 값으로 필요한 것들이다)
 	const propData: MeetingCardInfoProps & TagProps = {
+		id: data?.id,
 		title: data?.name,
 		location: data?.location,
 		meetingDate: formatDateOrTime(data?.dateTime, 'date'),
@@ -84,8 +85,11 @@ function CardBase({
 function JoinedMeetingCard({
 	isDone,
 	isCreated,
+	onCancelClick,
 	...props
-}: Partial<MeetingCardInfoProps & TagProps>) {
+}: Partial<MeetingCardInfoProps & TagProps> & {
+	onCancelClick: (e: React.MouseEvent, id: number) => void;
+}) {
 	const CreateReviewButton = dynamic(() => import('./CreateReviewButton'), {
 		loading: () => <Button>리뷰 작성하기</Button>,
 		ssr: !!false,
@@ -103,7 +107,15 @@ function JoinedMeetingCard({
 				<CardInfo {...(props as MeetingCardInfoProps)} />
 			</div>
 			{!!isDone && <CreateReviewButton />}
-			{!isDone && <Button>예약 취소하기</Button>}
+			{!isDone && (
+				<Button
+					onClick={(e) => {
+						onCancelClick(e, Number(props.id));
+					}}
+				>
+					예약 취소하기
+				</Button>
+			)}
 		</div>
 	);
 }

--- a/src/app/(home)/mypage/components/CardList/CardInfo.tsx
+++ b/src/app/(home)/mypage/components/CardList/CardInfo.tsx
@@ -1,6 +1,7 @@
 import Members from '@/components/Members/Members';
 
 export interface MeetingCardInfoProps {
+	id?: number;
 	title: string;
 	location: string;
 	meetingDate: string;

--- a/src/app/(home)/mypage/components/CardList/CardList.tsx
+++ b/src/app/(home)/mypage/components/CardList/CardList.tsx
@@ -7,9 +7,11 @@ import Link from 'next/link';
 interface CardListProps {
 	data: IMeeting[];
 	cardType: 'joined' | 'hosted';
+	/** 임시 */
+	onCancelClick?: (e: React.MouseEvent, id: number) => void;
 }
 
-function CardList({ data, cardType }: CardListProps) {
+function CardList({ data, cardType, onCancelClick }: CardListProps) {
 	return (
 		<div>
 			{data?.map((meeting) => (
@@ -20,7 +22,9 @@ function CardList({ data, cardType }: CardListProps) {
 				>
 					<CardBase data={meeting}>
 						{cardType === 'joined' ? (
-							<CardBase.JoinedMeetingCard />
+							<CardBase.JoinedMeetingCard
+								onCancelClick={(e, id) => onCancelClick!(e, id)} // 전달 시, e와 id를 넘겨줌
+							/>
 						) : (
 							<CardBase.HostedMeetingCard />
 						)}

--- a/src/app/(home)/mypage/components/CardList/CreateReviewButton.tsx
+++ b/src/app/(home)/mypage/components/CardList/CreateReviewButton.tsx
@@ -16,8 +16,6 @@ function CreateReviewButton() {
 
 				router.push(`/mypage/create-review/${1826}`, { scroll: false });
 			}}
-			state='default'
-			isOutlined={false}
 		>
 			리뷰 작성하기
 		</Button>

--- a/src/app/(home)/mypage/createdMeetings/page.tsx
+++ b/src/app/(home)/mypage/createdMeetings/page.tsx
@@ -5,13 +5,13 @@ import CardList from '../components/CardList/CardList';
 import { useAuthStore } from '@/store/useAuthStore';
 
 function Page() {
-	const userId = useAuthStore((state) => state.userId);
-
-	if (!userId) return null;
-
+	const userId = useAuthStore((state) => state.userId) ?? '';
 	const { meetings } = useMyMeetings('hosted', {
 		userId,
 	});
+
+	if (!userId) return null;
+
 	return <CardList data={meetings || []} cardType='hosted' />;
 }
 

--- a/src/app/(home)/mypage/page.tsx
+++ b/src/app/(home)/mypage/page.tsx
@@ -2,10 +2,48 @@
 
 import { useMyMeetings } from '@/hooks/customs/useMyMeetings';
 import CardList from './components/CardList/CardList';
+import { myMeetingService } from './components/CardList/Services/myMeetingService';
+import { IMeeting } from '@/types/meetingsType';
+import { useGlobalModal } from '@/hooks/customs/useGlobalModal';
+import { leaveGroup } from '@/api/detail-meeting/participantsGroup';
 
 function MyPage() {
-	const { meetings } = useMyMeetings('joined');
-	return <CardList data={meetings || []} cardType='joined' />;
+	const { meetings, setMeetings } = useMyMeetings('joined');
+	const { openModal, closeModal } = useGlobalModal();
+
+	/** 예약 취소 submit */
+	function onCancelClick(e: React.MouseEvent, id: number) {
+		e.preventDefault();
+		e.stopPropagation();
+
+		openModal({
+			content: '예약을 취소하시겠습니까?',
+			confirmType: 'Confirm',
+			onConfirm: async () => {
+				const res = await leaveGroup(id);
+
+				if (res) {
+					const data = await myMeetingService.fetchMyMeetings<IMeeting[]>({
+						completed: false,
+						reviewed: false,
+					});
+
+					if (data) {
+						setMeetings(data);
+						return closeModal();
+					}
+				}
+			},
+			onDismiss: closeModal,
+		});
+	}
+	return (
+		<CardList
+			data={meetings || []}
+			cardType='joined'
+			onCancelClick={(e, id) => onCancelClick(e, id)} // 전달 시, e와 id를 넘겨줌
+		/>
+	);
 }
 
 export default MyPage;

--- a/src/hooks/customs/useMyMeetings.tsx
+++ b/src/hooks/customs/useMyMeetings.tsx
@@ -47,5 +47,5 @@ export const useMyMeetings = (
 		fetchMeetings(pageKey, options || {});
 	}, []);
 
-	return { meetings };
+	return { meetings, setMeetings };
 };


### PR DESCRIPTION
**개요**

- 마이페이지 모임 참여 취소 기능을 추가하였습니다

**타입**

- [x] ✨feat: 기능 추가, 수정, 삭제
- [ ] 🐛fix: 버그, 오류 수정
- [ ] ⚙️config: npm 모듈 설치 , 설정 파일 추가, 라이브러리 추가 등
- [ ] 🌱chore: 그 외 기타 변경 사항에 대한 커밋(기타변경, 오탈자 수정,네이밍 변경 등)으로 프로덕션 코드 변경X
- [ ] 📝docs: README.md, json 파일 등 수정 (문서 관련, 코드 수정 없음)
- [ ] 🎨style: 코드 스타일 및 포맷 / CSS 등 사용자 UI 디자인 변경 (제품 코드 수정 발생, 코드 형식, 정렬 등의 변경)
- [ ] ♻️refactor: 코드 리팩토링
- [ ] 🧪test: 테스트 코드 추가, 삭제, 변경 등 (코드 수정 없음, 테스트 코드에 관련된 모든 변경에 해당)
- [ ] 🗑️remove: 파일을 삭제하는 작업만 수행한 경우

**작업 사항**

- `onCancelClick` 을 prop으로 전달하여 모임 참여 취소 api 호출을 하였습니다
- 임시로 prop으로 전달하고 있어서 향후 `useMutation` 과 custom hook 안에서 관리할 수 있도록 로직 분리 예정입니다
- 내가 참여한 모임 페이지에서 custom hook 호출 시 타입 오류를 `nullish` 병합 연산자로 수정하였습니다
- 남은 할 일
  - dialog 버튼 색 차이 없는 UI 수정  

**Others - optional**

- 스크린샷이나 참고한 링크
![-Chrome2025-02-2423-56-46-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/fd76d8a3-75a5-42d9-8c11-58b19c96ec58)

