### PR TITLE
feat: 찜한 모임에서 찜하기 취소 시 아이템 삭제 기능 추가(+ 모임 제목 출력)

### DIFF
--- a/src/app/(home)/favorite-meetings/components/CardList/CardList.tsx
+++ b/src/app/(home)/favorite-meetings/components/CardList/CardList.tsx
@@ -71,7 +71,10 @@ function CardList() {
 							</Card.Header.Left>
 
 							<Card.Header.Right>
-								<LikeButton itemId={el.id ?? 0} />
+								<LikeButton
+									itemId={el.id ?? 0}
+									onLikeChangeHandler={deleteLikeMeetings}
+								/>
 							</Card.Header.Right>
 						</Card.Header>
 

--- a/src/app/(home)/favorite-meetings/components/CardList/CardList.tsx
+++ b/src/app/(home)/favorite-meetings/components/CardList/CardList.tsx
@@ -42,11 +42,11 @@ function CardList() {
 							<Card.Header.Left
 								title={
 									el.type === 'OFFICE_STRETCHING'
-										? '달램핏 마인드풀니스 |'
+										? el.name
 										: el.type === 'MINDFULNESS'
-											? '달램핏 마인드풀니스 |'
+											? el.name
 											: el.type === 'WORKATION'
-												? '워크에이션 리프레쉬 |'
+												? el.name
 												: ''
 								}
 								place={el.location}

--- a/src/hooks/customs/useFavoriteMeetings.tsx
+++ b/src/hooks/customs/useFavoriteMeetings.tsx
@@ -1,39 +1,63 @@
 import { useQuery } from '@tanstack/react-query';
 import { meetingService } from '@/app/(home)/favorite-meetings/meetingService';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useAuthStore } from '@/store/useAuthStore';
 import { IMeeting } from '@/types/meetingsType';
+// import { useLikeNotify } from './useLikeNotify';
 
-export const useFavoriteMeetings = () => {
-	// 로컬 스토리지에서 찜한 아이디 목록 가져오기
-	function getLocalStorageItem<T>(key: string, defaultValue: T): T {
-		try {
-			const storedValue = localStorage.getItem(key);
-			if (storedValue) {
-				return JSON.parse(storedValue) as T;
-			} else {
-				return defaultValue;
-			}
-		} catch (error) {
-			console.error(
-				`Error parsing JSON from localStorage for key "${key}":`,
-				error,
-			);
+// 로컬 스토리지에서 값을 가져오는 함수
+/** utils로 변경 예정 */
+function getLocalStorageItem<T>(key: string, defaultValue: T): T {
+	try {
+		const storedValue = localStorage.getItem(key);
+		if (storedValue) {
+			return JSON.parse(storedValue) as T;
+		} else {
 			return defaultValue;
 		}
+	} catch (error) {
+		console.error(
+			`Error parsing JSON from localStorage for key "${key}":`,
+			error,
+		);
+		return defaultValue;
 	}
+}
 
-	const [filteredMeetings, setFilteredMeetings] = useState<IMeeting[]>([]);
-	const { userId, isLoggedIn, hasHydrated } = useAuthStore();
+/** 로그인한 사용자 또는 guest ID를 반환하는 함수 */
+/** utils로 변경 예정 */
+function getLikerKey({
+	likeList,
+	user,
+	isLoggedIn,
+}: {
+	likeList: ILikeListJSON;
+	user: number | null;
+	isLoggedIn: boolean;
+}) {
+	return Object.keys(likeList).find((key) => {
+		if (!(user && isLoggedIn)) {
+			// 로그인되지 않은 경우 guestId를 사용
+			const guestId = getLocalStorageItem<string>('guestId', '');
+			return Number(key) === Number(guestId);
+		}
+		return Number(key) === Number(user);
+	});
+}
 
+interface ILikeListJSON {
+	[key: string]: number[] | string[];
+}
+
+export const useFavoriteMeetings = () => {
 	// 데이터 가져오는 함수
 	const getData = async () => {
-		console.log(
-			'로컬에서 가져온 userId값 있음?',
-			'ID값: ',
-			userId,
-			hasHydrated,
-		);
+		// console.log(
+		// 	'로컬에서 가져온 userId값 있음?',
+		// 	'ID값: ',
+		// 	userId,
+		// 	hasHydrated,
+		// );
 
 		// 로그인한 유저 가져오기 전에는 api 호출하지 않음
 		if (!hasHydrated) {
@@ -46,21 +70,66 @@ export const useFavoriteMeetings = () => {
 			isLoggedIn,
 			// 나중에 필터 추가
 		});
-		return setFilteredMeetings(res);
+		return res; // 반드시 데이터를 반환
 	};
+	// const { likeNotification } = useLikeNotify();
+	const { userId, isLoggedIn, hasHydrated } = useAuthStore();
+	const [localKeys, setLocalKeys] = useState('');
 
-	// React Query로 서버에서 모임 데이터 가져오기
+	// 데이터를 state로 저장
+	const [filteredMeetings, setFilteredMeetings] = useState<IMeeting[]>([]);
+
+	// likeList는 최신 상태 유지
+	const likeList = getLocalStorageItem<ILikeListJSON>('likes', {});
+
+	const likerKey = hasHydrated
+		? getLikerKey({ likeList, user: userId, isLoggedIn })
+		: null;
+
 	const { data, isLoading, error } = useQuery({
-		queryKey: userId ? ['favorite', userId] : [], // userId가 있을 때만 쿼리 키 설정
+		queryKey: likerKey ? ['favorite', likerKey, localKeys] : [],
 		queryFn: getData,
 	});
 
-	const deleteLikeMeetings = () => {
-		setFilteredMeetings(() => {
-			return filteredMeetings?.filter((item) => {
-				[1000].includes(item.id);
+	// data가 업데이트되면 상태를 변경
+	useEffect(() => {
+		if (data) {
+			setFilteredMeetings(data);
+		}
+	}, [data]);
+
+	/** 찜 상태 변경될 때마다 */
+	// useEffect(() => {
+	// 	const latestLikeList = getLocalStorageItem<
+	// 		Record<string, number[] | string[]>
+	// 	>('likes', {});
+	// 	if (!likerKey) {
+	// 		return;
+	// 	}
+
+	// 	// 로컬 key 업데이트(리액트 쿼리 키 변동)
+	// 	setLocalKeys(latestLikeList[likerKey]?.join(''));
+	// }, [likeNotification]);
+
+	/** 찜 상태가 변경될 때 찜한 모임에서 실행되는 함수 */
+	const deleteLikeMeetings = (isLike: boolean) => {
+		if (!isLike) {
+			const latestLikeList = getLocalStorageItem<
+				Record<string, number[] | string[]>
+			>('likes', {});
+
+			if (!likerKey) {
+				return;
+			}
+
+			setFilteredMeetings(() => {
+				const filterList = filteredMeetings?.filter((item) => {
+					return (latestLikeList[likerKey] as number[])?.includes(item.id);
+				});
+
+				return filterList;
 			});
-		});
+		}
 	};
 
 	return {


### PR DESCRIPTION
**개요**

- 찜한 모임 페이지에서 사용자가 찜하기를 취소했을 때 해당 아이템이 보이지 않도록 처리하였습니다

**타입**

- [x] ✨feat: 기능 추가, 수정, 삭제
- [ ] 🐛fix: 버그, 오류 수정
- [ ] ⚙️config: npm 모듈 설치 , 설정 파일 추가, 라이브러리 추가 등
- [ ] 🌱chore: 그 외 기타 변경 사항에 대한 커밋(기타변경, 오탈자 수정,네이밍 변경 등)으로 프로덕션 코드 변경X
- [ ] 📝docs: README.md, json 파일 등 수정 (문서 관련, 코드 수정 없음)
- [ ] 🎨style: 코드 스타일 및 포맷 / CSS 등 사용자 UI 디자인 변경 (제품 코드 수정 발생, 코드 형식, 정렬 등의 변경)
- [ ] ♻️refactor: 코드 리팩토링
- [ ] 🧪test: 테스트 코드 추가, 삭제, 변경 등 (코드 수정 없음, 테스트 코드에 관련된 모든 변경에 해당)
- [ ] 🗑️remove: 파일을 삭제하는 작업만 수행한 경우

**작업 사항**

- 찜한 모임 페이지에서 찜하기를 취소하면 서버에 추가 모임 정보를 요청하지 않고 클라이언트에서 필터링할 수 있도록 구현하였습니다
- 리액트 쿼리 키 동적 생성을 위해 로컬 스토리지에 저장된 찜한 모임 id를 문자열로 생성하여 상태 변수로 관리하였습니다
  - 현재는 다른 브랜치에서 아직 안 합쳐와서 주석 처리되어 있는 상태입니다 
- 다음에 해야 할 일
  - stale 타임 지정, inactivateQuery 지점 정하기
  - 쿼리 key 를 동적으로 생성할 때 해시값 비교 여부 판단

**Others - optional**

- 스크린샷이나 참고한 링크
