### PR TITLE
feat: useLikeNotify hook 에서 찜한 개수 바로 불러올 수 있도록 상태 추가

### DIFF
--- a/src/hooks/customs/useLikeNotify.tsx
+++ b/src/hooks/customs/useLikeNotify.tsx
@@ -1,6 +1,6 @@
 import { useAuthStore } from '@/store/useAuthStore';
 import useNotificationStore from '@/store/useNotificationStore';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 
 // 로컬 스토리지에서 값을 가져오는 함수
 /** utils로 변경 예정 */
@@ -64,6 +64,13 @@ export const useLikeNotify = () => {
 	const likerKey = hasHydrated
 		? getLikerKey({ likeList, user: userId, isLoggedIn })
 		: null;
+
+	useEffect(() => {
+		if (!likerKey) return;
+
+		const count = likeList[likerKey]?.length ?? 0;
+		updateNotification(pageKey, count > 0, count);
+	}, []);
 
 	// 최신 localStorage 값을 가져오는 onChangeLike
 	const onChangeLike = useCallback(() => {

--- a/src/hooks/customs/useLikeNotify.tsx
+++ b/src/hooks/customs/useLikeNotify.tsx
@@ -54,7 +54,9 @@ export const useLikeNotify = () => {
 	const updateNotification = useNotificationStore(
 		(state) => state.updateNotification,
 	);
+	const { notifications } = useNotificationStore();
 	const pageKey = 'favorite-meetings';
+	const likeNotification = notifications[pageKey];
 
 	// likeList는 최신 상태 유지
 	const likeList = getLocalStorageItem<ILikeListJSON>('likes', {});
@@ -74,8 +76,9 @@ export const useLikeNotify = () => {
 		}
 
 		const count = latestLikeList[likerKey]?.length ?? 0;
+
 		updateNotification(pageKey, count > 0, count);
 	}, [likerKey, updateNotification, pageKey]);
 
-	return { onChangeLike };
+	return { onChangeLike, likeNotification };
 };


### PR DESCRIPTION
**개요**

- `useLikeNotify` hook 에서 찜한 상태 전역 변수를 반환하도록 추가하였습니다

**타입**

- [ ] ✨feat: 기능 추가, 수정, 삭제
- [ ] 🐛fix: 버그, 오류 수정
- [ ] ⚙️config: npm 모듈 설치 , 설정 파일 추가, 라이브러리 추가 등
- [ ] 🌱chore: 그 외 기타 변경 사항에 대한 커밋(기타변경, 오탈자 수정,네이밍 변경 등)으로 프로덕션 코드 변경X
- [ ] 📝docs: README.md, json 파일 등 수정 (문서 관련, 코드 수정 없음)
- [ ] 🎨style: 코드 스타일 및 포맷 / CSS 등 사용자 UI 디자인 변경 (제품 코드 수정 발생, 코드 형식, 정렬 등의 변경)
- [ ] ♻️refactor: 코드 리팩토링
- [ ] 🧪test: 테스트 코드 추가, 삭제, 변경 등 (코드 수정 없음, 테스트 코드에 관련된 모든 변경에 해당)
- [ ] 🗑️remove: 파일을 삭제하는 작업만 수행한 경우

**작업 사항**

-  `useLikeNotify` hook 에서 찜한 상태 전역 변수를 반환하도록 추가하였습니다
- 남은 작업
  - 현재 `useNotificationStore` 에서 관리하고있는 찜한 페이지 찜 개수의 초기 상태 값이 `count` 가 0으로 고정되어 있어 로컬 스토리지에서 초기 값을 가져오는 `persist`의 적용이 필요합니다 

**Others - optional**

- 스크린샷이나 참고한 링크
