### PR TITLE
feat: 찜한 모임 페이지 모임 종류 필터링 추가

### DIFF
--- a/src/app/(home)/favorite-meetings/layout.tsx
+++ b/src/app/(home)/favorite-meetings/layout.tsx
@@ -1,5 +1,6 @@
 import PageInfo from '@/components/PageInfo/PageInfo';
 import PageNavbar from '@/components/PageNav/PageNavbar';
+import FilterProvider from '@/context/FilterContent';
 
 type Props = {
 	children: React.ReactNode;
@@ -9,8 +10,10 @@ function FavoriteMeetingLayout({ children }: Props) {
 	return (
 		<section className='mt-6 flex flex-col gap-5 md:max-w-[996px] mx-auto min-h-screen'>
 			<PageInfo pageKey='saved' />
-			<PageNavbar pageKey='meetings' />
-			<div>{children}</div>
+			<FilterProvider>
+				<PageNavbar pageKey='meetings' />
+				<div>{children}</div>
+			</FilterProvider>
 		</section>
 	);
 }

--- a/src/hooks/customs/useFavoriteMeetings.tsx
+++ b/src/hooks/customs/useFavoriteMeetings.tsx
@@ -3,6 +3,8 @@ import { meetingService } from '@/app/(home)/favorite-meetings/meetingService';
 import { useEffect, useState } from 'react';
 import { useAuthStore } from '@/store/useAuthStore';
 import { IMeeting } from '@/types/meetingsType';
+import { useFilter } from './useFilter';
+// import { useLikeNotify } from './useLikeNotify';
 // import { useLikeNotify } from './useLikeNotify';
 
 // 로컬 스토리지에서 값을 가져오는 함수
@@ -50,6 +52,7 @@ interface ILikeListJSON {
 }
 
 export const useFavoriteMeetings = () => {
+	const { type } = useFilter();
 	// 데이터 가져오는 함수
 	const getData = async () => {
 		// console.log(
@@ -68,7 +71,7 @@ export const useFavoriteMeetings = () => {
 		const res = await meetingService.getFavoriteMeetings({
 			userId,
 			isLoggedIn,
-			// 나중에 필터 추가
+			type,
 		});
 		return res; // 반드시 데이터를 반환
 	};
@@ -87,7 +90,7 @@ export const useFavoriteMeetings = () => {
 		: null;
 
 	const { data, isLoading, error } = useQuery({
-		queryKey: likerKey ? ['favorite', likerKey, localKeys] : [],
+		queryKey: likerKey ? ['favorite', likerKey, localKeys, type] : [],
 		queryFn: getData,
 	});
 

--- a/src/hooks/customs/useFavoriteMeetings.tsx
+++ b/src/hooks/customs/useFavoriteMeetings.tsx
@@ -4,8 +4,7 @@ import { useEffect, useState } from 'react';
 import { useAuthStore } from '@/store/useAuthStore';
 import { IMeeting } from '@/types/meetingsType';
 import { useFilter } from './useFilter';
-// import { useLikeNotify } from './useLikeNotify';
-// import { useLikeNotify } from './useLikeNotify';
+import { useLikeNotify } from './useLikeNotify';
 
 // 로컬 스토리지에서 값을 가져오는 함수
 /** utils로 변경 예정 */
@@ -75,7 +74,7 @@ export const useFavoriteMeetings = () => {
 		});
 		return res; // 반드시 데이터를 반환
 	};
-	// const { likeNotification } = useLikeNotify();
+	const { likeNotification } = useLikeNotify();
 	const { userId, isLoggedIn, hasHydrated } = useAuthStore();
 	const [localKeys, setLocalKeys] = useState('');
 
@@ -102,17 +101,17 @@ export const useFavoriteMeetings = () => {
 	}, [data]);
 
 	/** 찜 상태 변경될 때마다 */
-	// useEffect(() => {
-	// 	const latestLikeList = getLocalStorageItem<
-	// 		Record<string, number[] | string[]>
-	// 	>('likes', {});
-	// 	if (!likerKey) {
-	// 		return;
-	// 	}
+	useEffect(() => {
+		const latestLikeList = getLocalStorageItem<
+			Record<string, number[] | string[]>
+		>('likes', {});
+		if (!likerKey) {
+			return;
+		}
 
-	// 	// 로컬 key 업데이트(리액트 쿼리 키 변동)
-	// 	setLocalKeys(latestLikeList[likerKey]?.join(''));
-	// }, [likeNotification]);
+		// 로컬 key 업데이트(리액트 쿼리 키 변동)
+		setLocalKeys(latestLikeList[likerKey]?.join(''));
+	}, [likeNotification]);
 
 	/** 찜 상태가 변경될 때 찜한 모임에서 실행되는 함수 */
 	const deleteLikeMeetings = (isLike: boolean) => {


### PR DESCRIPTION
**개요**

- 찜한 모임 페이지의 모임 종류별 필터링 기능을 연결하였습니다

**타입**

- [x] ✨feat: 기능 추가, 수정, 삭제
- [ ] 🐛fix: 버그, 오류 수정
- [ ] ⚙️config: npm 모듈 설치 , 설정 파일 추가, 라이브러리 추가 등
- [ ] 🌱chore: 그 외 기타 변경 사항에 대한 커밋(기타변경, 오탈자 수정,네이밍 변경 등)으로 프로덕션 코드 변경X
- [ ] 📝docs: README.md, json 파일 등 수정 (문서 관련, 코드 수정 없음)
- [ ] 🎨style: 코드 스타일 및 포맷 / CSS 등 사용자 UI 디자인 변경 (제품 코드 수정 발생, 코드 형식, 정렬 등의 변경)
- [ ] ♻️refactor: 코드 리팩토링
- [ ] 🧪test: 테스트 코드 추가, 삭제, 변경 등 (코드 수정 없음, 테스트 코드에 관련된 모든 변경에 해당)
- [ ] 🗑️remove: 파일을 삭제하는 작업만 수행한 경우

**작업 사항**

- `useFilter` hook 이 반환하는 필터 속성들로 api 요청을 할 수 있도록 하였습니다
- `FilterProvider` contextAPI를 찜한 모임 페이지 `layout.tsx`에 적용하였습니다

**Others - optional**

- 스크린샷이나 참고한 링크
- 
![-Chrome2025-02-2515-37-23-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/6b2bd31c-e451-4587-b066-ee60a7bae6e9)

