### PR TITLE
fix: 프로필 사진 없을 시 프로필 폼 진입 오류 수정

### DIFF
--- a/src/app/(home)/mypage/components/ProfileForm/ProfileForm.tsx
+++ b/src/app/(home)/mypage/components/ProfileForm/ProfileForm.tsx
@@ -4,7 +4,7 @@ import Button from '@/components/Button/Button';
 import Dialog from '@/components/Dialog/Dialog';
 import ProfileInput from '../ProfileInput/ProfileInput';
 import FormControl from './FormControl';
-import { FormEvent, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { editProfile } from '@/api/users';
 import { getUserData } from '@/api/getUserData';
 import type { IUser } from '@/types/userType';
@@ -33,7 +33,11 @@ function ProfileForm() {
 
 	useEffect(() => {
 		// formState가 변경될 때마다 유효성 검사
-		const isValid = Object.values(formState).every((val) => val.trim() !== '');
+		/**
+		 * @history 2025-02-26 swagger 기준 프로필 이미지 등록이 필수값으로 이해했는데 null 값이 허용임을 확인 -> 회사명 빈 값으로만 유효성 검사 수정
+		 */
+		// const isValid = Object.values(formState).every((val) => val.trim() !== '');
+		const isValid = formState.companyName?.trim()?.length !== 0;
 		setIsValid(isValid);
 	}, [formState]); // formState가 변경될 때마다 실행됨
 
@@ -42,7 +46,7 @@ function ProfileForm() {
 	const getData = async () => {
 		const data = await getUserData();
 		setUserData(data);
-		setFormState({ image: data?.image, companyName: data?.companyName });
+		setFormState({ image: data?.image ?? '', companyName: data?.companyName });
 	};
 	// const userData: Promise<IUser> = getData();
 


### PR DESCRIPTION
**개요**

- 프로필 사진이 없을 때 프로필 유효성 검사 value 값 검사 시 null 값을 처리하지 못한 오류를 수정하였습니다

**타입**

- [ ] ✨feat: 기능 추가, 수정, 삭제
- [x] 🐛fix: 버그, 오류 수정
- [ ] ⚙️config: npm 모듈 설치 , 설정 파일 추가, 라이브러리 추가 등
- [ ] 🌱chore: 그 외 기타 변경 사항에 대한 커밋(기타변경, 오탈자 수정,네이밍 변경 등)으로 프로덕션 코드 변경X
- [ ] 📝docs: README.md, json 파일 등 수정 (문서 관련, 코드 수정 없음)
- [ ] 🎨style: 코드 스타일 및 포맷 / CSS 등 사용자 UI 디자인 변경 (제품 코드 수정 발생, 코드 형식, 정렬 등의 변경)
- [ ] ♻️refactor: 코드 리팩토링
- [ ] 🧪test: 테스트 코드 추가, 삭제, 변경 등 (코드 수정 없음, 테스트 코드에 관련된 모든 변경에 해당)
- [ ] 🗑️remove: 파일을 삭제하는 작업만 수행한 경우

**작업 사항**

- 유효성 검사 변경 : 이미지 없고, 회사명 빈 값일 경우 -> 회사명만 빈 값일 경우로 false 처리
- 프로필 사진이 없는 유저의 정보를 받아올 경우 `image: null` 을 빈 문자열로 처리

**Others - optional**

- 스크린샷이나 참고한 링크
