### PR TITLE
feat: 로그아웃 시 알림 뱃지 초기화 기능 추가

### DIFF
--- a/src/hooks/customs/useAuth.tsx
+++ b/src/hooks/customs/useAuth.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import { useAuthStore } from '@/store/useAuthStore';
 import { jwtDecode } from 'jwt-decode';
+import useNotificationStore from '@/store/useNotificationStore';
 
 //함수: 토큰 디코딩하여 시간 만료되었는지 유효성 검증
 const isTokenExpired = (token: string): boolean => {
@@ -21,6 +22,7 @@ const isTokenExpired = (token: string): boolean => {
 const useAuth = () => {
 	const pathname = usePathname();
 	const router = useRouter();
+	const { resetNotifications } = useNotificationStore();
 	// 상태관리 변수
 	const setUserNull = useAuthStore((state) => state.setUserNull);
 
@@ -28,6 +30,7 @@ const useAuth = () => {
 	const logoutUser = () => {
 		localStorage.removeItem('authToken');
 		setUserNull();
+		resetNotifications();
 		console.log('로그아웃 되었습니다. 메인 페이지로 이동합니다');
 		router.push('/login');
 	};

--- a/src/store/useNotificationStore.tsx
+++ b/src/store/useNotificationStore.tsx
@@ -7,6 +7,7 @@ interface NotificationState {
 		hasNotification: boolean,
 		count?: number,
 	) => void;
+	resetNotifications: () => void;
 }
 
 const useNotificationStore = create<NotificationState>((set) => ({
@@ -22,6 +23,18 @@ const useNotificationStore = create<NotificationState>((set) => ({
 				[key]: { hasNotification, count },
 			},
 		}));
+	},
+	resetNotifications: () => {
+		set((state) => {
+			const resetState = Object.keys(state.notifications).reduce(
+				(acc, key) => {
+					acc[key] = { hasNotification: false, count: 0 };
+					return acc;
+				},
+				{} as Record<string, { hasNotification: boolean; count: number }>,
+			);
+			return { notifications: resetState };
+		});
 	},
 }));
 


### PR DESCRIPTION
**개요**

- 로그아웃시 사용자의 알림을 초기화하는 기능을 추가하였습니다

**타입**

- [x] ✨feat: 기능 추가, 수정, 삭제
- [ ] 🐛fix: 버그, 오류 수정
- [ ] ⚙️config: npm 모듈 설치 , 설정 파일 추가, 라이브러리 추가 등
- [ ] 🌱chore: 그 외 기타 변경 사항에 대한 커밋(기타변경, 오탈자 수정,네이밍 변경 등)으로 프로덕션 코드 변경X
- [ ] 📝docs: README.md, json 파일 등 수정 (문서 관련, 코드 수정 없음)
- [ ] 🎨style: 코드 스타일 및 포맷 / CSS 등 사용자 UI 디자인 변경 (제품 코드 수정 발생, 코드 형식, 정렬 등의 변경)
- [ ] ♻️refactor: 코드 리팩토링
- [ ] 🧪test: 테스트 코드 추가, 삭제, 변경 등 (코드 수정 없음, 테스트 코드에 관련된 모든 변경에 해당)
- [ ] 🗑️remove: 파일을 삭제하는 작업만 수행한 경우

**작업 사항**

- `useNotificationStore` 전역 상태 변수에 `resetNotifications` 상태 set 함수 추가
- 로그아웃 시 실행되도록 `useAuth` custom hook `logoutUser` 에서 호출

**Others - optional**

- 스크린샷이나 참고한 링크
- 
![-Chrome2025-02-2709-34-14-ezgif com-crop](https://github.com/user-attachments/assets/0132c061-4b41-4dfe-931e-03527de287a6)

