### PR TITLE
fix: 찜한 모임 가져오는 쿼리에 enabled 속성 추가

### DIFF
--- a/src/hooks/customs/useFavoriteMeetings.tsx
+++ b/src/hooks/customs/useFavoriteMeetings.tsx
@@ -39,10 +39,9 @@ export const useFavoriteMeetings = () => {
 			: null;
 
 	const { data, isLoading, error } = useQuery({
-		queryKey: likerKey
-			? ['favorite', likerKey, likeList[likerKey]?.join('')]
-			: [],
-		queryFn: getData,
+		queryKey: ['favorite', likerKey ? likeList[likerKey]?.join('') : ''],
+		queryFn: () => (likerKey ? getData() : null),
+		enabled: !!likerKey,
 	});
 
 	// data가 업데이트되면 상태를 변경

--- a/src/hooks/customs/useFavoriteMeetings.tsx
+++ b/src/hooks/customs/useFavoriteMeetings.tsx
@@ -16,13 +16,6 @@ export const useFavoriteMeetings = () => {
 	const { type } = useFilter();
 	// 데이터 가져오는 함수
 	const getData = async () => {
-		// console.log(
-		// 	'로컬에서 가져온 userId값 있음?',
-		// 	'ID값: ',
-		// 	userId,
-		// 	hasHydrated,
-		// );
-
 		// 아이디 목록을 기준으로 API 호출
 		const res = await meetingService.getFavoriteMeetings({
 			userId,


### PR DESCRIPTION
**개요**

- 찜한 모임 가져오는 query 에 enabled 속성을 추가하여 좋아요한 사람을 가져올 수 없을 때에는 실행되지 않도록 수정하였습니다

**타입**

- [ ] ✨feat: 기능 추가, 수정, 삭제
- [ ] 🐛fix: 버그, 오류 수정
- [ ] ⚙️config: npm 모듈 설치 , 설정 파일 추가, 라이브러리 추가 등
- [ ] 🌱chore: 그 외 기타 변경 사항에 대한 커밋(기타변경, 오탈자 수정,네이밍 변경 등)으로 프로덕션 코드 변경X
- [ ] 📝docs: README.md, json 파일 등 수정 (문서 관련, 코드 수정 없음)
- [ ] 🎨style: 코드 스타일 및 포맷 / CSS 등 사용자 UI 디자인 변경 (제품 코드 수정 발생, 코드 형식, 정렬 등의 변경)
- [x] ♻️refactor: 코드 리팩토링
- [ ] 🧪test: 테스트 코드 추가, 삭제, 변경 등 (코드 수정 없음, 테스트 코드에 관련된 모든 변경에 해당)
- [ ] 🗑️remove: 파일을 삭제하는 작업만 수행한 경우

**작업 사항**

- enabled 속성 추가로 불필요한 캐싱 최소화

**Others - optional**

- 스크린샷이나 참고한 링크
