### PR TITLE
fix: 프로필 수정시 헤더에도 적용되게 임시 적용

### DIFF
--- a/src/app/(home)/mypage/components/ProfileForm/ProfileForm.tsx
+++ b/src/app/(home)/mypage/components/ProfileForm/ProfileForm.tsx
@@ -63,9 +63,16 @@ function ProfileForm() {
 		const formData = new FormData(e.currentTarget);
 		const data = await editProfile(formData);
 
+		const refreshPreviousPage = () => {
+			router.back(); // 이전 페이지로 이동
+			setTimeout(() => {
+				router.refresh(); // 이전 페이지 새로고침
+			}, 100); // 약간의 딜레이를 줘야 적용됨
+		};
+
 		if (data) {
 			// useMutation 으로 변경 예정
-			return router.back();
+			refreshPreviousPage();
 		}
 	};
 	return (

--- a/src/app/(home)/mypage/components/ProfileHeader/ProfileHeader.tsx
+++ b/src/app/(home)/mypage/components/ProfileHeader/ProfileHeader.tsx
@@ -6,17 +6,40 @@ import Image from 'next/image';
 import type { IUser } from '@/types/userType';
 import { getUserData } from '@/api/getUserData';
 import { useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { useAuthStore } from '@/store/useAuthStore';
 
 function ProfileHeader() {
 	const [data, setData] = useState<IUser>();
+
+	/** 임시 */
+	const pathname = usePathname();
+	const userSetter = useAuthStore();
+
+	const setters: { [key: string]: (value: any) => void } = {
+		setImage: userSetter.setImage,
+	};
+
 	const getData = async () => {
 		const userData = await getUserData();
 		setData(userData);
+
+		/** 임시 */
+		/** 전역에도 반영 */
+		// 데이터 순회하면서 각 setter 함수 호출
+		Object.keys(setters).forEach((key) => {
+			const setterFunction = setters[key];
+			const field = key.replace('set', '').toLowerCase(); // 예: setUserId -> userId
+			setterFunction(userData[field as keyof typeof userData]); // 동적으로 setter 함수 호출
+		});
 	};
 
+	/** 임시 */
 	useEffect(() => {
-		getData();
-	}, []);
+		if (pathname === '/mypage') {
+			getData();
+		}
+	}, [pathname]);
 
 	const { name, email, companyName, image } = data ?? {};
 

--- a/src/components/GNB/ProfileTooltip.tsx
+++ b/src/components/GNB/ProfileTooltip.tsx
@@ -5,20 +5,26 @@ import Link from 'next/link';
 import { useAuth } from '@/hooks/customs/useAuth';
 import { IUser } from '@/types/userType';
 import { getUserData } from '@/api/getUserData';
+import { usePathname } from 'next/navigation';
 
 const ProfileTooltip = () => {
 	const { logoutUser } = useAuth();
 	const [data, setData] = useState<IUser | null>(null);
 	const [visible, setVisible] = useState(false);
 
+	const pathname = usePathname();
+
 	const getData = async () => {
 		const userData = await getUserData();
 		setData(userData);
 	};
 
+	/** 임시 */
 	useEffect(() => {
-		getData();
-	}, []);
+		if (pathname === '/mypage') {
+			getData();
+		}
+	}, [pathname]);
 
 	if (!data) return null; // 여기에서 return null을 해야 함
 


### PR DESCRIPTION
**개요**

- 프로필 수정시 헤더에는 적용되지 않는 버그를 헤더에도 적용되게 임시 수정하였습니다

**타입**

- [ ] ✨feat: 기능 추가, 수정, 삭제
- [x] 🐛fix: 버그, 오류 수정
- [ ] ⚙️config: npm 모듈 설치 , 설정 파일 추가, 라이브러리 추가 등
- [ ] 🌱chore: 그 외 기타 변경 사항에 대한 커밋(기타변경, 오탈자 수정,네이밍 변경 등)으로 프로덕션 코드 변경X
- [ ] 📝docs: README.md, json 파일 등 수정 (문서 관련, 코드 수정 없음)
- [ ] 🎨style: 코드 스타일 및 포맷 / CSS 등 사용자 UI 디자인 변경 (제품 코드 수정 발생, 코드 형식, 정렬 등의 변경)
- [ ] ♻️refactor: 코드 리팩토링
- [ ] 🧪test: 테스트 코드 추가, 삭제, 변경 등 (코드 수정 없음, 테스트 코드에 관련된 모든 변경에 해당)
- [ ] 🗑️remove: 파일을 삭제하는 작업만 수행한 경우

**작업 사항**

- profile 이미지 수정 후 modal 닫았을 때 실행되는 `router.back()` 호출 후 1초 뒤 해당 페이지를 refresh 하도록 추가(진짜 임시)
- `router.back()` 으로 변경된 `pathname` 을 감지하여 프로필 수정 이후 다시 설정하도록 변경(전역 상태를 호출하도록 변경 예정, 진짜 임시)

**Others - optional**

- 스크린샷이나 참고한 링크
- 이후 추가하겠습니다
