### PR TITLE
refator: 프로필 수정 시 바로 헤더에 적용되도록 전역 변수 사용

### DIFF
--- a/src/app/(home)/mypage/components/ProfileForm/ProfileForm.tsx
+++ b/src/app/(home)/mypage/components/ProfileForm/ProfileForm.tsx
@@ -13,6 +13,7 @@ import { useProfile, useProfileActions } from '@/store/useAuthStore';
 function ProfileForm() {
 	const router = useRouter();
 	const { image, companyName, email } = useProfile();
+	const { setImage, setCompanyName } = useProfileActions();
 	const [formState, setFormState] = useState<Record<string, string | null>>({
 		image: image,
 		companyName: companyName,
@@ -45,18 +46,12 @@ function ProfileForm() {
 	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
 		const formData = new FormData(e.currentTarget);
-		const data = await editProfile(formData);
-
-		const refreshPreviousPage = () => {
-			router.back(); // 이전 페이지로 이동
-			setTimeout(() => {
-				router.refresh(); // 이전 페이지 새로고침
-			}, 100); // 약간의 딜레이를 줘야 적용됨
-		};
+		const data: IUser = await editProfile(formData);
 
 		if (data) {
-			// useMutation 으로 변경 예정
-			refreshPreviousPage();
+			setImage(data.image);
+			setCompanyName(data.companyName);
+			router.back();
 		}
 	};
 	return (

--- a/src/app/(home)/mypage/components/ProfileForm/ProfileForm.tsx
+++ b/src/app/(home)/mypage/components/ProfileForm/ProfileForm.tsx
@@ -6,15 +6,16 @@ import ProfileInput from '../ProfileInput/ProfileInput';
 import FormControl from './FormControl';
 import { useEffect, useState } from 'react';
 import { editProfile } from '@/api/users';
-import { getUserData } from '@/api/getUserData';
 import type { IUser } from '@/types/userType';
 import { useRouter } from 'next/navigation';
+import { useProfile, useProfileActions } from '@/store/useAuthStore';
 
 function ProfileForm() {
-	const [userData, setUserData] = useState<IUser | null>();
-	const [formState, setFormState] = useState<Record<string, string>>({
-		image: '',
-		companyName: '',
+	const router = useRouter();
+	const { image, companyName, email } = useProfile();
+	const [formState, setFormState] = useState<Record<string, string | null>>({
+		image: image,
+		companyName: companyName,
 	});
 
 	// 폼 유효성 상태
@@ -41,23 +42,6 @@ function ProfileForm() {
 		setIsValid(isValid);
 	}, [formState]); // formState가 변경될 때마다 실행됨
 
-	const router = useRouter();
-
-	const getData = async () => {
-		const data = await getUserData();
-		setUserData(data);
-		setFormState({ image: data?.image ?? '', companyName: data?.companyName });
-	};
-	// const userData: Promise<IUser> = getData();
-
-	useEffect(() => {
-		getData();
-	}, []);
-
-	if (!userData) {
-		return <div>로딩 중...</div>;
-	}
-
 	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
 		const formData = new FormData(e.currentTarget);
@@ -81,14 +65,14 @@ function ProfileForm() {
 				<Dialog.Content title='프로필 수정하기'>
 					<div className='flex flex-col gap-4 mb-[24px]'>
 						<ProfileInput
-							image={userData?.image}
+							image={formState.image}
 							onImageChange={handleFormChange}
 						/>
 						<FormControl.InputControl
 							id='company'
 							title='회사'
 							name='companyName'
-							value={formState.companyName}
+							value={formState.companyName ?? ''}
 							onChange={handleFormChange}
 						/>
 						<FormControl.InputControl
@@ -96,7 +80,7 @@ function ProfileForm() {
 							title='이메일'
 							name='email'
 							disabled={true}
-							value={userData?.email}
+							value={email ?? ''}
 							readOnly={true}
 						/>
 					</div>

--- a/src/app/(home)/mypage/components/ProfileHeader/ProfileHeader.tsx
+++ b/src/app/(home)/mypage/components/ProfileHeader/ProfileHeader.tsx
@@ -3,47 +3,10 @@
 import Link from 'next/link';
 import ProfileIcon from '../ProfileIcon/ProfileIcon';
 import Image from 'next/image';
-import type { IUser } from '@/types/userType';
-import { getUserData } from '@/api/getUserData';
-import { useEffect, useState } from 'react';
-import { usePathname } from 'next/navigation';
-import { useAuthStore } from '@/store/useAuthStore';
+import { useProfile } from '@/store/useAuthStore';
 
 function ProfileHeader() {
-	const [data, setData] = useState<IUser>();
-
-	/** 임시 */
-	const pathname = usePathname();
-	const userSetter = useAuthStore();
-
-	const setters: { [key: string]: (value: any) => void } = {
-		setImage: userSetter.setImage,
-	};
-
-	const getData = async () => {
-		const userData = await getUserData();
-		setData(userData);
-
-		/** 임시 */
-		/** 전역에도 반영 */
-		// 데이터 순회하면서 각 setter 함수 호출
-		Object.keys(setters).forEach((key) => {
-			const setterFunction = setters[key];
-			const field = key.replace('set', '').toLowerCase(); // 예: setUserId -> userId
-			setterFunction(userData[field as keyof typeof userData]); // 동적으로 setter 함수 호출
-		});
-	};
-
-	/** 임시 */
-	useEffect(() => {
-		if (pathname === '/mypage') {
-			getData();
-		}
-	}, [pathname]);
-
-	const { name, email, companyName, image } = data ?? {};
-
-	/** zustand/reactQuery 로 변경할 예정 */
+	const { name, email, companyName, image } = useProfile();
 	return (
 		<section className='border border-2 border-gray-200 rounded-3xl overflow-hidden'>
 			<div className='bg-primary-400 flex items-center justify-between pl-6 pr-4 py-4'>

--- a/src/app/(home)/mypage/components/ProfileInput/ProfileInput.tsx
+++ b/src/app/(home)/mypage/components/ProfileInput/ProfileInput.tsx
@@ -6,7 +6,7 @@ function ProfileInput({
 	image,
 	onImageChange,
 }: {
-	image: string;
+	image: string | null;
 	onImageChange?: (e: ChangeEvent<HTMLInputElement>) => void;
 }) {
 	const [preview, setPreview] = useState<string | null | FileReader['result']>(

--- a/src/components/GNB/ProfileTooltip.tsx
+++ b/src/components/GNB/ProfileTooltip.tsx
@@ -1,39 +1,14 @@
 'use client';
-import { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useAuth } from '@/hooks/customs/useAuth';
-import { IUser } from '@/types/userType';
-import { getUserData } from '@/api/getUserData';
-import { usePathname } from 'next/navigation';
+import { useProfile } from '@/store/useAuthStore';
+import { useState } from 'react';
 
 const ProfileTooltip = () => {
 	const { logoutUser } = useAuth();
-	const [data, setData] = useState<IUser | null>(null);
 	const [visible, setVisible] = useState(false);
-
-	const pathname = usePathname();
-
-	const getData = async () => {
-		const userData = await getUserData();
-		setData(userData);
-	};
-
-	/** 임시 */
-	useEffect(() => {
-		if (pathname === '/mypage') {
-			getData();
-		}
-	}, [pathname]);
-
-	/** 임시 */
-	useEffect(() => {
-		getData();
-	}, []);
-
-	if (!data) return null; // 여기에서 return null을 해야 함
-
-	const image = data.image;
+	const { image } = useProfile();
 
 	const toggleTooltip = () => setVisible((prev) => !prev);
 
@@ -53,7 +28,7 @@ const ProfileTooltip = () => {
 			}}
 		>
 			<Image
-				src={image}
+				src={src}
 				alt=''
 				fill
 				className='object-cover rounded-full overflow-hidden'

--- a/src/store/useAuthStore.tsx
+++ b/src/store/useAuthStore.tsx
@@ -1,6 +1,7 @@
 import { Store } from '@/types/userType';
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { useShallow } from 'zustand/react/shallow';
 
 const useAuthStore = create<Store & { hasHydrated: boolean }>()(
 	persist(
@@ -42,5 +43,30 @@ const useAuthStore = create<Store & { hasHydrated: boolean }>()(
 		},
 	),
 );
+
+// 프로필 관련 state 반환
+export const useProfile = () =>
+	useAuthStore(
+		useShallow((state) => {
+			return {
+				name: state.name,
+				image: state.image,
+				companyName: state.companyName,
+				email: state.email,
+			};
+		}),
+	);
+
+// 프로필 관련 actions 반환
+export const useProfileActions = () =>
+	useAuthStore(
+		useShallow((state) => {
+			const { setCompanyName, setImage } = state;
+			return {
+				setCompanyName,
+				setImage,
+			};
+		}),
+	);
 
 export { useAuthStore };


### PR DESCRIPTION
**개요**

- 프로필 수정 시 바로 헤더에 적용되도록 전역 변수를 사용하도록 변경하였습니다

**타입**

- [ ] ✨feat: 기능 추가, 수정, 삭제
- [x] 🐛fix: 버그, 오류 수정
- [ ] ⚙️config: npm 모듈 설치 , 설정 파일 추가, 라이브러리 추가 등
- [ ] 🌱chore: 그 외 기타 변경 사항에 대한 커밋(기타변경, 오탈자 수정,네이밍 변경 등)으로 프로덕션 코드 변경X
- [ ] 📝docs: README.md, json 파일 등 수정 (문서 관련, 코드 수정 없음)
- [ ] 🎨style: 코드 스타일 및 포맷 / CSS 등 사용자 UI 디자인 변경 (제품 코드 수정 발생, 코드 형식, 정렬 등의 변경)
- [x] ♻️refactor: 코드 리팩토링
- [ ] 🧪test: 테스트 코드 추가, 삭제, 변경 등 (코드 수정 없음, 테스트 코드에 관련된 모든 변경에 해당)
- [ ] 🗑️remove: 파일을 삭제하는 작업만 수행한 경우

**작업 사항**

- 유저 전역 변수에 프로필 관련 custom hook 추가
  - 💁‍♀️따로 분리한 이유? -> 필요한 상태 관리 로직을 customhook 으로 반환하려는 의도  
  [참고]https://hyunjinee.notion.site/Working-with-Zustand-73c2d6bbb53d4c6e9944ddc5e23706a1#2cb39464db75424fbe00cdd2a42e14ec
 
- 일부 컴포넌트 개별 사용자 정보 api 호출하는 useEffect 제거 및 전역 변수 사용하도록 변경
  - `ProfileForm.tsx`
  - `ProfileHeader.tsx`
  - `ProfileTooltip.tsx`

**Others - optional**

- 스크린샷이나 참고한 링크
- 
![-Chrome2025-03-0923-21-52-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/ecfd12b5-f102-41d4-b269-1b1078f59b97)

