### PR TITLE
[1차 QA 반영] style: 마이페이지에서 프로필 사진 기본 배경색 처리

### DIFF
--- a/src/app/(home)/mypage/components/ProfileHeader/ProfileHeader.tsx
+++ b/src/app/(home)/mypage/components/ProfileHeader/ProfileHeader.tsx
@@ -26,7 +26,7 @@ function ProfileHeader() {
 					<ProfileIcon.Avatar size='small' className='relative bottom-5' />
 				)}
 				{!!image && (
-					<div className='relative bottom-5 border border-2 border-white max-h-[56px] basis-[56px] rounded-full overflow-hidden'>
+					<div className='relative bottom-5 border border-2 border-white max-h-[56px] basis-[56px] rounded-full overflow-hidden bg-[url(/icons/profileDefault.svg)] bg-cover bg-center'>
 						<Image src={image} alt='' fill className='object-cover' />
 					</div>
 				)}

--- a/src/app/(home)/mypage/components/ProfileHeader/ProfileHeader.tsx
+++ b/src/app/(home)/mypage/components/ProfileHeader/ProfileHeader.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import ProfileIcon from '../ProfileIcon/ProfileIcon';
 import Image from 'next/image';
+import ProfileIcon from '../ProfileIcon/ProfileIcon';
 import { useProfile } from '@/store/useAuthStore';
 
 function ProfileHeader() {

--- a/src/app/(home)/mypage/components/ProfileInput/ProfileInput.tsx
+++ b/src/app/(home)/mypage/components/ProfileInput/ProfileInput.tsx
@@ -1,6 +1,6 @@
-import { ChangeEvent, FormEvent, useEffect, useState } from 'react';
-import ProfileIcon from '../ProfileIcon/ProfileIcon';
 import Image from 'next/image';
+import { ChangeEvent, useEffect, useState } from 'react';
+import ProfileIcon from '../ProfileIcon/ProfileIcon';
 
 function ProfileInput({
 	image,

--- a/src/app/(home)/mypage/components/ProfileInput/ProfileInput.tsx
+++ b/src/app/(home)/mypage/components/ProfileInput/ProfileInput.tsx
@@ -58,7 +58,7 @@ function ProfileInput({
 			<label htmlFor='profile-file' className='cursor-pointer inline-block'>
 				{!preview && <ProfileIcon.EditProfile />}
 				{!!preview && (
-					<div className='relative rounded-full max-w-[56px] min-w-[56px] min-h-[56px] overflow-hidden'>
+					<div className='relative rounded-full max-w-[56px] min-w-[56px] min-h-[56px] overflow-hidden bg-[url(/icons/profileDefault.svg)] bg-cover bg-center'>
 						<Image
 							src={preview as string}
 							alt='프로필 사진'


### PR DESCRIPTION
**개요**

- 1차 QA - `백그라운드 예시` 관련 마이페이지의 프로필 수정 폼과 프로필 헤더에서 기본 배경색 처리하였습니다

**타입**

- [ ] ✨feat: 기능 추가, 수정, 삭제
- [ ] 🐛fix: 버그, 오류 수정
- [ ] ⚙️config: npm 모듈 설치 , 설정 파일 추가, 라이브러리 추가 등
- [ ] 🌱chore: 그 외 기타 변경 사항에 대한 커밋(기타변경, 오탈자 수정,네이밍 변경 등)으로 프로덕션 코드 변경X
- [ ] 📝docs: README.md, json 파일 등 수정 (문서 관련, 코드 수정 없음)
- [x] 🎨style: 코드 스타일 및 포맷 / CSS 등 사용자 UI 디자인 변경 (제품 코드 수정 발생, 코드 형식, 정렬 등의 변경)
- [ ] ♻️refactor: 코드 리팩토링
- [ ] 🧪test: 테스트 코드 추가, 삭제, 변경 등 (코드 수정 없음, 테스트 코드에 관련된 모든 변경에 해당)
- [ ] 🗑️remove: 파일을 삭제하는 작업만 수행한 경우

**작업 사항**

- `/icons/profileDefault.svg` 적용

**Others - optional**

- 스크린샷이나 참고한 링크
- 전
![image](https://github.com/user-attachments/assets/b02e2fd9-0380-4daf-869f-e7ab41a5e18b)

- 후
![image](https://github.com/user-attachments/assets/0734feb5-80bf-4a75-ad93-0fbb9b2470ea)


