### PR TITLE
style: 모든 리뷰 페이지 style 변경 및 더보기 추가

### DIFF
--- a/src/components/ReviewCard/ReviewCard.tsx
+++ b/src/components/ReviewCard/ReviewCard.tsx
@@ -23,9 +23,8 @@ export default function ReviewCard({
 }
 
 function ImageSection({ src }: { src?: string }) {
-	const sizes = '(max-width: 640px) 343px, (max-width: 1024px) 280px, 100vw';
 	return (
-		<div className='relative w-full md:w-[280px] h-[156px] md:mb-3 md:mr-5 rounded-[24px] overflow-hidden'>
+		<div className='relative w-full sm:w-[280px] h-[156px] md:mb-3 md:mr-5 rounded-[24px] overflow-hidden'>
 			{src && src.trim() ? (
 				<Image
 					src={src}
@@ -33,7 +32,6 @@ function ImageSection({ src }: { src?: string }) {
 					fill
 					priority
 					className='object-cover'
-					sizes={sizes}
 				/>
 			) : (
 				<Image
@@ -41,7 +39,6 @@ function ImageSection({ src }: { src?: string }) {
 					alt='기본 리뷰 이미지'
 					fill
 					className='object-cover'
-					sizes={sizes}
 				/>
 			)}
 		</div>

--- a/src/components/ReviewCard/ReviewCard.tsx
+++ b/src/components/ReviewCard/ReviewCard.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import HeartRatings from '../HeartRatings/HeartRatings';
 import ProfileIcon from '@/app/(home)/mypage/components/ProfileIcon/ProfileIcon';
+import { useState } from 'react';
 
 export default function ReviewCard({
 	children,
@@ -77,7 +78,36 @@ function HeartScore({ score }: { score: number }) {
 }
 
 function Content({ comment }: { comment: string }) {
-	return <div className='text-md mb-3'>{comment}</div>;
+	const [expanded, setExpanded] = useState(false);
+	const MAX_LENGTH = 300;
+
+	const shouldTruncate = comment.length > MAX_LENGTH;
+	const displayedText =
+		expanded || !shouldTruncate ? comment : comment.slice(0, MAX_LENGTH);
+
+	return (
+		<div className='text-md mb-3'>
+			<p>
+				{displayedText}
+				{shouldTruncate && !expanded && (
+					<span
+						onClick={() => setExpanded(true)}
+						className='text-gray-500 font-normal hover:text-gray-900 cursor-pointer'
+					>
+						...더보기
+					</span>
+				)}
+			</p>
+			{expanded && (
+				<button
+					onClick={() => setExpanded(false)}
+					className='text-gray-500 font-normal hover:text-gray-900'
+				>
+					접기
+				</button>
+			)}
+		</div>
+	);
 }
 
 function EtcInfo({

--- a/src/components/ReviewCard/ReviewCard.tsx
+++ b/src/components/ReviewCard/ReviewCard.tsx
@@ -15,7 +15,7 @@ export default function ReviewCard({
 			<div className='flex flex-col flex-wrap md:flex-row w-full md:w-full h-full relative'>
 				{children}
 				{isDetailPage === false && (
-					<div className='flex absolute -bottom-4 mb-3 sm:mb-0 w-full border-t border-5 border-dashed border-gray-200'></div>
+					<div className='flex absolute -bottom-4 mb-3 sm:mb-0 w-full border-t-2 border-5 border-dashed border-gray-200'></div>
 				)}
 			</div>
 		</div>
@@ -54,13 +54,13 @@ function ReviewLayout({
 }) {
 	return (
 		<div
-			className={`flex-1 relative h-full text-gray-700 font-medium ${
+			className={`flex-1 relative text-gray-700 font-medium ${
 				isDetailPage ? 'min-h-[100px]' : 'min-h-[156px]'
 			}`}
 		>
 			{children}
 			{isDetailPage && (
-				<div className='flex absolute bottom-0 w-full border-t border-dashed border-gray-200'></div>
+				<div className='flex absolute -bottom-4 w-full border-t-2 border-5 border-dashed border-gray-200'></div>
 			)}
 		</div>
 	);


### PR DESCRIPTION
**개요**
모든 리뷰 페이지 css 변경 및 리뷰 더보기 기능 추가


**타입**
- [x] ✨feat: 기능 추가, 수정, 삭제
- [ ] 🐛fix: 버그, 오류 수정
- [ ] ⚙️config: npm 모듈 설치 , 설정 파일 추가, 라이브러리 추가 등
- [x] 🌱chore: 그 외 기타 변경 사항에 대한 커밋(기타변경, 오탈자 수정,네이밍 변경 등)으로 프로덕션 코드 변경X
- [ ] 📝docs: README.md, json 파일 등 수정 (문서 관련, 코드 수정 없음)
- [x] 🎨style: 코드 스타일 및 포맷 / CSS 등 사용자 UI 디자인 변경 (제품 코드 수정 발생, 코드 형식, 정렬 등의 변경)
- [ ] ♻️refactor: 코드 리팩토링
- [ ] 🧪test: 테스트 코드 추가, 삭제, 변경 등 (코드 수정 없음, 테스트 코드에 관련된 모든 변경에 해당)
- [ ] 🗑️remove: 파일을 삭제하는 작업만 수행한 경우


**작업 사항**
- 리뷰 조회 시 글자를 300자로 제한하여 더보기 기능을 추가하였습니다.
- 리뷰 카드 이미지 섹션에서 적용되지 않는 코드를 삭제하고, 이미지 크기를 변경하였습니다.
- 구분선 스타일을 변경하였습니다. 

**Others - optional**
테스트 해둔 리뷰의 길이가 길어짐에 따라 피그마대로 구분선을 적용하는 것보다, 리뷰 조회 시 최대한 리뷰 내용을 확인하면 좋겠다는 생각이 들었습니다. 현재 피그마와 다르게 sm~md사이의 배치를 다르게 가져갔고,  구분선 스타일을 디테일과 모든 리뷰에서 동일하게 설정하였습니다. 아래 스크린샷을 참고하시고 어색한 부분이 있으면 말씀해주세요🤗


- 동영상 (모든리뷰)

https://github.com/user-attachments/assets/907115f5-f59b-4ff1-be19-d2e3c9ac1633


- 스크린샷 (디테일) : 리뷰에서 이미지를 제거하면 적용되는 모습

![스크린샷 2025-03-12 002511](https://github.com/user-attachments/assets/b431f05d-3f25-4ad3-a7ce-28fc5814c913)

