### PR TITLE
feat: 프로필 툴팁 외부 클릭시 사라지도록 함

### DIFF
--- a/src/components/GNB/ProfileTooltip.tsx
+++ b/src/components/GNB/ProfileTooltip.tsx
@@ -3,17 +3,35 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useAuth } from '@/hooks/customs/useAuth';
 import { useProfile } from '@/store/useAuthStore';
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 const ProfileTooltip = () => {
 	const { logoutUser } = useAuth();
 	const [visible, setVisible] = useState(false);
 
 	const { image } = useProfile();
-  const src = image ?? '/icons/profileDefault.svg';
+	const src = image ?? '/icons/profileDefault.svg';
 	const toggleTooltip = () => setVisible((prev) => !prev);
+	const tooltipRef = useRef<HTMLDivElement>(null); // 참조 생성
+
+	// 외부 클릭 감지
+	useEffect(() => {
+		const handleClickOutside = (event: MouseEvent) => {
+			if (!tooltipRef.current) return; // 🔥 `null` 체크 추가
+			if (!tooltipRef.current.contains(event.target as Node)) {
+				setVisible(false);
+			}
+		};
+
+		document.addEventListener('mousedown', handleClickOutside);
+		return () => {
+			document.removeEventListener('mousedown', handleClickOutside);
+		};
+	}, []);
+
 	return (
 		<div
+			ref={tooltipRef}
 			className='relative '
 			onClick={toggleTooltip}
 			style={{


### PR DESCRIPTION
**개요**

- 간단한 PR 요약 내용
fix: 프로필 툴팁 외부 클릭시 사라지도록 함

**타입**

- [V ] ✨feat: 기능 추가, 수정, 삭제
- [ ] 🐛fix: 버그, 오류 수정
- [ ] ⚙️config: npm 모듈 설치 , 설정 파일 추가, 라이브러리 추가 등
- [ ] 🌱chore: 그 외 기타 변경 사항에 대한 커밋(기타변경, 오탈자 수정,네이밍 변경 등)으로 프로덕션 코드 변경X
- [ ] 📝docs: README.md, json 파일 등 수정 (문서 관련, 코드 수정 없음)
- [ ] 🎨style: 코드 스타일 및 포맷 / CSS 등 사용자 UI 디자인 변경 (제품 코드 수정 발생, 코드 형식, 정렬 등의 변경)
- [ ] ♻️refactor: 코드 리팩토링
- [ ] 🧪test: 테스트 코드 추가, 삭제, 변경 등 (코드 수정 없음, 테스트 코드에 관련된 모든 변경에 해당)
- [ ] 🗑️remove: 파일을 삭제하는 작업만 수행한 경우

**작업 사항**

- 작업 내용을 상세하게 적어주세요.
기존: 프로필 이미지를 클릭해야만 툴팁이 닫힘
현재: 툴팁 외부를 클릭해도 툴팁이 닫힘


**Others - optional**

- 스크린샷이나 참고한 링크
