### PR TITLE
fix: 리뷰 날짜 필터링 코드 수정 (재수정)

### DIFF
--- a/src/app/(home)/all-reviews/_components/ReviewCardList.tsx
+++ b/src/app/(home)/all-reviews/_components/ReviewCardList.tsx
@@ -17,7 +17,16 @@ function ReviewCardList({ filters }: { filters: FilterType }) {
 				(review, index, self) =>
 					self.findIndex((r) => r.id === review.id) === index,
 			) ?? [];
-	const isReviewEmpty = reviews.length === 0;
+
+	// 모임 날짜, 필터링 날짜 비교 로직
+	const filteredReviews = filters?.date
+		? reviews.filter((review) => {
+				const reviewDate = review.Gathering.dateTime.split('T')[0];
+				return reviewDate === filters.date;
+			})
+		: reviews;
+
+	const isReviewEmpty = filteredReviews.length === 0;
 
 	const { ref, inView } = useInView();
 
@@ -41,7 +50,7 @@ function ReviewCardList({ filters }: { filters: FilterType }) {
 				<Msg message='아직 리뷰가 없어요' />
 			) : (
 				<>
-					{reviews.map((review: ReviewType) => (
+					{filteredReviews.map((review: ReviewType) => (
 						<ReviewCard key={review.id}>
 							<ReviewCard.ImageSection
 								src={review.Gathering.image || undefined}

--- a/src/app/(home)/all-reviews/_components/ReviewCardList.tsx
+++ b/src/app/(home)/all-reviews/_components/ReviewCardList.tsx
@@ -64,6 +64,7 @@ function ReviewCardList({ filters }: { filters: FilterType }) {
 									type={review.Gathering.type}
 									location={review.Gathering.location}
 									date={review.createdAt}
+									gatheringDate={review.Gathering.dateTime}
 								/>
 							</ReviewCard.ReviewLayout>
 						</ReviewCard>

--- a/src/app/(home)/all-reviews/_components/ReviewCardList.tsx
+++ b/src/app/(home)/all-reviews/_components/ReviewCardList.tsx
@@ -18,15 +18,7 @@ function ReviewCardList({ filters }: { filters: FilterType }) {
 					self.findIndex((r) => r.id === review.id) === index,
 			) ?? [];
 
-	// 모임 날짜, 필터링 날짜 비교 로직
-	const filteredReviews = filters?.date
-		? reviews.filter((review) => {
-				const reviewDate = review.Gathering.dateTime.split('T')[0];
-				return reviewDate === filters.date;
-			})
-		: reviews;
-
-	const isReviewEmpty = filteredReviews.length === 0;
+	const isReviewEmpty = reviews.length === 0;
 
 	const { ref, inView } = useInView();
 
@@ -50,7 +42,7 @@ function ReviewCardList({ filters }: { filters: FilterType }) {
 				<Msg message='아직 리뷰가 없어요' />
 			) : (
 				<>
-					{filteredReviews.map((review: ReviewType) => (
+					{reviews.map((review: ReviewType) => (
 						<ReviewCard key={review.id}>
 							<ReviewCard.ImageSection
 								src={review.Gathering.image || undefined}

--- a/src/components/ReviewCard/ReviewCard.tsx
+++ b/src/components/ReviewCard/ReviewCard.tsx
@@ -120,7 +120,7 @@ function EtcInfo({
 	userIcon?: string;
 	nickname?: string;
 	date: string;
-	gatheringDate: string;
+	gatheringDate?: string;
 }) {
 	const formatDate = (date: Date | string): string => {
 		return new Date(date).toISOString().split('T')[0].replace(/-/g, '.');
@@ -138,7 +138,7 @@ function EtcInfo({
 
 	return (
 		<div className='flex flex-col text-xs'>
-			{type && location && (
+			{type && location && gatheringDate && (
 				<div className='mb-2'>
 					<span>{formatType(type)}</span>
 					<span className='mx-1'>·</span>

--- a/src/components/ReviewCard/ReviewCard.tsx
+++ b/src/components/ReviewCard/ReviewCard.tsx
@@ -113,12 +113,14 @@ function EtcInfo({
 	userIcon,
 	nickname,
 	date,
+	gatheringDate,
 }: {
 	type?: string;
 	location?: string;
 	userIcon?: string;
 	nickname?: string;
 	date: string;
+	gatheringDate: string;
 }) {
 	const formatDate = (date: Date | string): string => {
 		return new Date(date).toISOString().split('T')[0].replace(/-/g, '.');
@@ -138,9 +140,11 @@ function EtcInfo({
 		<div className='flex flex-col text-xs'>
 			{type && location && (
 				<div className='mb-2'>
-					<span>{formatType(type)} 이용</span>
+					<span>{formatType(type)}</span>
 					<span className='mx-1'>·</span>
 					<span>{location}</span>
+					<span className='mx-1'>·</span>
+					<span>{formatDate(gatheringDate)} 이용</span>
 				</div>
 			)}
 			<div className='flex flex-wrap items-center content-between w-fit whitespace-nowrap'>


### PR DESCRIPTION
**개요**
모든 리뷰에서 날짜를 필터링이 안되는 부분이 있어 로직을 추가하였습니다.
-> 백엔드 api 오류 수정으로 인해 코드 추가 로직 부분을 삭제하였습니다.

**타입**

- [x] ✨feat: 기능 추가, 수정, 삭제
- [x] 🐛fix: 버그, 오류 수정
- [ ] ⚙️config: npm 모듈 설치 , 설정 파일 추가, 라이브러리 추가 등
- [ ] 🌱chore: 그 외 기타 변경 사항에 대한 커밋(기타변경, 오탈자 수정,네이밍 변경 등)으로 프로덕션 코드 변경X
- [ ] 📝docs: README.md, json 파일 등 수정 (문서 관련, 코드 수정 없음)
- [ ] 🎨style: 코드 스타일 및 포맷 / CSS 등 사용자 UI 디자인 변경 (제품 코드 수정 발생, 코드 형식, 정렬 등의 변경)
- [ ] ♻️refactor: 코드 리팩토링
- [ ] 🧪test: 테스트 코드 추가, 삭제, 변경 등 (코드 수정 없음, 테스트 코드에 관련된 모든 변경에 해당)
- [ ] 🗑️remove: 파일을 삭제하는 작업만 수행한 경우

**작업 사항**
모임 날짜와 필터링의 날짜를 비교하는 로직을 추가해, 일치하는 리뷰 데이터만 나오게 구현하였습니다. (삭제한 로직)
리뷰 카드에 모임 날짜도 추가하였습니다.


**Others - optional**
모든 리뷰에서는 api 파라미터로 모임날짜, 모임 모집 마감 날짜를 받는데 파라미터를 활용하기 위해 날짜 필터링을 모임날짜로 설정하였습니다. 리뷰에서는 리뷰 날짜로 필터링 하지 않는 동작이 어색할 수도 있을 것 같아 모임 날짜를 카드에 추가하였습니다!

- 스크린샷

![image](https://github.com/user-attachments/assets/8e1c4a90-15c9-488d-8c0d-c82d13d94dcc)

